### PR TITLE
Skeleton Zarr server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # qupath-ext-cloud-omezarr
 QuPath extension to load OME-Zarr images from cloud storage
+
+## Experimental extension ⚠️
+
+⚠️ Use this extension at your own risk
+
+Its API & behavior are likely to change.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,10 @@ qupathExtension {
   automaticModule = "io.github.dimi-lab.qupath.extension.cloud-omezarr"
 }
 
+tasks.named("build") {
+  dependsOn("shadowJar")
+}
+
 kotlin {
   jvmToolchain(17)
 }

--- a/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/CloudOmeZarrServer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/CloudOmeZarrServer.kt
@@ -1,0 +1,87 @@
+package dimilab.qupath.ext.cloud_omezarr
+
+import qupath.lib.images.servers.AbstractTileableImageServer
+import qupath.lib.images.servers.ImageChannel
+import qupath.lib.images.servers.ImageServerBuilder
+import qupath.lib.images.servers.ImageServerBuilder.DefaultImageServerBuilder
+import qupath.lib.images.servers.ImageServerMetadata
+import qupath.lib.images.servers.TileRequest
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.awt.image.BufferedImage.TYPE_INT_ARGB
+import java.awt.image.BufferedImage.TYPE_INT_RGB
+import java.net.URI
+
+
+class CloudOmeZarrServer(val uri: URI, vararg args: String) : AbstractTileableImageServer() {
+  companion object {
+    private val logger = org.slf4j.LoggerFactory.getLogger(CloudOmeZarrServer::class.java)
+  }
+
+  private val metadata: ImageServerMetadata
+  private val serverArgs = args
+
+  init {
+    logger.info("Creating CloudOmeZarrServer from $uri with args ${args.joinToString(" ")}")
+
+    // TODO: implement metadata
+
+    // hardcoded values for now:
+    metadata = ImageServerMetadata.Builder()
+      .width(1000)
+      .height(1000)
+      .levelsFromDownsamples(1.0)
+      .channels(ImageChannel.getDefaultRGBChannels())
+      .preferredTileSize(100, 100)
+      .build()
+  }
+
+  override fun getURIs(): MutableCollection<URI> {
+    return arrayListOf(uri)
+  }
+
+  override fun getServerType(): String {
+    return "Cloud OME-ZARR"
+  }
+
+  override fun getOriginalMetadata(): ImageServerMetadata {
+    return metadata
+  }
+
+  override fun createServerBuilder(): ImageServerBuilder.ServerBuilder<BufferedImage> {
+    return DefaultImageServerBuilder.createInstance(
+      CloudOmeZarrServerBuilder::class.java,
+      metadata,
+      uri,
+      *serverArgs,
+    )
+  }
+
+  override fun createID(): String {
+    return "CloudOmeZarrServer: $uri ${serverArgs.joinToString(" ")}"
+  }
+
+  override fun readTile(tileRequest: TileRequest?): BufferedImage {
+    // TODO: implement tile reading
+
+    logger.debug("Reading tile: {}", tileRequest)
+
+    val width = tileRequest!!.tileWidth
+    val height = tileRequest.tileHeight
+
+    val img = BufferedImage(width, height, TYPE_INT_ARGB)
+
+    val rgb = Color(255, 0, 255).rgb
+    val startW = (width * 0.1).toInt()
+    val endW = (width * 0.9).toInt()
+    val startH = (height * 0.1).toInt()
+    val endH = (height * 0.9).toInt()
+    (startW..endW).forEach { x ->
+      (startH..endH).forEach { y ->
+        img.setRGB(x, y, rgb)
+      }
+    }
+
+    return img
+  }
+}

--- a/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/CloudOmeZarrServerBuilder.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/CloudOmeZarrServerBuilder.kt
@@ -1,0 +1,93 @@
+package dimilab.qupath.ext.cloud_omezarr
+
+import qupath.lib.images.servers.ImageServer
+import qupath.lib.images.servers.ImageServerBuilder
+import qupath.lib.images.servers.ImageServerBuilder.DefaultImageServerBuilder
+import qupath.lib.images.servers.ImageServerBuilder.UriImageSupport
+import qupath.lib.images.servers.ImageServerMetadata
+import java.awt.image.BufferedImage
+import java.net.URI
+
+class CloudOmeZarrServerBuilder : ImageServerBuilder<BufferedImage> {
+  companion object {
+    private val logger = org.slf4j.LoggerFactory.getLogger(CloudOmeZarrServerBuilder::class.java)
+  }
+
+  override fun checkImageSupport(uri: URI?, vararg args: String?): UriImageSupport<BufferedImage>? {
+    logger.info("Checking image support for CloudOmeZarrServerBuilder: $uri")
+    if (uri == null) {
+      return null
+    }
+    if (!supportedSchema(uri)) {
+      return null
+    }
+
+    // TODO: look for an omezarr structure at the URI
+    if (!uri.path.endsWith(".zattrs")) {
+      return null
+    }
+
+    // At this point, we should validate that it's a single image
+    // In other words the structure should be:
+    // - uri (the omezarr root)
+    //   - OME
+    //   - <image_name from series in OME/.zattrs>
+    //     - levels of detail (aka multiscale)
+    //       <coordinates>
+    // But for now … no
+
+    // I guess we should read in the metadata at this point?
+    // But for now … no
+    val metadata: ImageServerMetadata? = null
+
+    // Technically 4 is the highest
+    // https://github.com/qupath/qupath/blob/a30510b98a6a91b1a79bbf08789565c53bb127b4/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerBuilder.java#L267-L288
+    // …but I see the Bioformats Extension uses 5 for its formats eg OMETIFF
+    // https://github.com/petebankhead/qupath/blob/a30510b98a6a91b1a79bbf08789565c53bb127b4/qupath-extension-bioformats/src/main/java/qupath/lib/images/servers/bioformats/BioFormatsServerBuilder.java#L76-L77
+    // So for now … 5
+    // (Do we need 5.1 to take precedence over bio-formats in upcoming qupath 0.6?)
+    val supportLevel = 5f
+
+    return UriImageSupport.createInstance(
+      this.javaClass,
+      supportLevel,
+      listOf(
+        DefaultImageServerBuilder.createInstance(
+          this.javaClass,
+          metadata,
+          uri,
+          *args
+        )
+      )
+    )
+  }
+
+  private fun supportedSchema(uri: URI?): Boolean {
+    return uri?.scheme == "gs" || uri?.scheme == "file"
+  }
+
+  override fun buildServer(uri: URI?, vararg args: String): ImageServer<BufferedImage>? {
+    if (uri == null) {
+      return null
+    }
+
+    try {
+      return CloudOmeZarrServer(uri, *args)
+    } catch (e: Exception) {
+      logger.error("Cloud OME-Zarr couldn't open {}: {}", uri, e.message, e)
+      return null
+    }
+  }
+
+  override fun getName(): String {
+    return "Cloud OME-Zarr builder"
+  }
+
+  override fun getDescription(): String {
+    return "Image server for OME-Zarr files stored in the cloud"
+  }
+
+  override fun getImageType(): Class<BufferedImage> {
+    return BufferedImage::class.java
+  }
+}

--- a/src/main/resources/META-INF/services/qupath.lib.images.servers.ImageServerBuilder
+++ b/src/main/resources/META-INF/services/qupath.lib.images.servers.ImageServerBuilder
@@ -1,0 +1,1 @@
+dimilab.qupath.ext.cloud_omezarr.CloudOmeZarrServerBuilder


### PR DESCRIPTION
Adds a CloudOmeZarrServer and corresponding builder. For now, the builder recognizes all files ending in .zattrs and applies no validation. Then the image server hard-codes a 1000x1000 image with RGB channels, filled with 100 tiles filled with color 0xff00ff (pink).

When added to QuPath, this renders a loaded .zattrs file as a grid of pink tiles. Yay :)

<img width="1382" alt="Screenshot 2025-03-09 at 11 13 32 PM" src="https://github.com/user-attachments/assets/83fe2fad-4e10-4e02-ab77-2b6bbf063b2d" />