### PR TITLE
Read from google cloud storage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,10 @@ dependencies {
   implementation("org.openmicroscopy:ome-model:6.4.0")
   implementation("dev.zarr:jzarr:0.4.2")
 
+  // Google Cloud Storage NIO filesystem
+  implementation(platform("com.google.cloud:libraries-bom:23.0.0"))
+  implementation("com.google.cloud:google-cloud-nio")
+
   // For testing
   testImplementation(libs.bundles.qupath)
   testImplementation(kotlin("test"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ tasks.named("build") {
 }
 
 kotlin {
-  jvmToolchain(17)
+  jvmToolchain(21)
 }
 
 dependencies {
@@ -55,6 +55,7 @@ dependencies {
   // For testing
   testImplementation(libs.bundles.qupath)
   testImplementation(kotlin("test"))
+  testImplementation("io.mockk:mockk:1.13.17")
 }
 
 repositories {

--- a/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeXmlUtils.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeXmlUtils.kt
@@ -1,7 +1,6 @@
 package dimilab.qupath.ext.cloud_omezarr
 
 import dimilab.qupath.ext.cloud_omezarr.OmeXmlUtils.Companion.logger
-import loci.common.RandomAccessInputStream
 import loci.common.services.ServiceFactory
 import loci.common.xml.XMLTools
 import loci.formats.ome.OMEXMLMetadata
@@ -11,11 +10,12 @@ import org.slf4j.Logger
 import org.xml.sax.SAXException
 import qupath.lib.common.ColorTools
 import qupath.lib.images.servers.ImageChannel
+import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.nio.file.Path
 import javax.xml.parsers.ParserConfigurationException
 import javax.xml.transform.TransformerException
-import kotlin.io.path.absolutePathString
+import kotlin.io.path.readBytes
 
 
 class OmeXmlUtils {
@@ -34,8 +34,8 @@ fun parseOmeXmlMetadata(omeRoot: Path): OMEXMLMetadata {
 
 fun readOmeXml(metadataFile: Path): String {
   val omeDocument = try {
-    val measurement = RandomAccessInputStream(metadataFile.absolutePathString())
-    XMLTools.parseDOM(measurement)
+    val stream = ByteArrayInputStream(metadataFile.readBytes())
+    XMLTools.parseDOM(stream)
   } catch (e: ParserConfigurationException) {
     throw IOException(e)
   } catch (e: SAXException) {

--- a/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeXmlUtils.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeXmlUtils.kt
@@ -25,8 +25,11 @@ class OmeXmlUtils {
 }
 
 fun parseOmeXmlMetadata(omeRoot: Path): OMEXMLMetadata {
-  val xml = readOmeXml(omeRoot.resolve("METADATA.ome.xml"))
+  val xmlPath = omeRoot.resolve("METADATA.ome.xml")
+  logger.debug("Reading OME XML metadata from {}", xmlPath)
+  val xml = readOmeXml(xmlPath)
 
+  logger.debug("Parsing OME XML metadata")
   val service = ServiceFactory().getInstance(OMEXMLService::class.java)
   return service.createOMEXMLMetadata(xml)
 }

--- a/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeXmlUtils.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeXmlUtils.kt
@@ -12,11 +12,10 @@ import org.xml.sax.SAXException
 import qupath.lib.common.ColorTools
 import qupath.lib.images.servers.ImageChannel
 import java.io.IOException
-import java.net.URI
+import java.nio.file.Path
 import javax.xml.parsers.ParserConfigurationException
 import javax.xml.transform.TransformerException
 import kotlin.io.path.absolutePathString
-import kotlin.io.path.toPath
 
 
 class OmeXmlUtils {
@@ -25,9 +24,7 @@ class OmeXmlUtils {
   }
 }
 
-fun parseOmeXmlMetadata(omeRoot: URI): OMEXMLMetadata {
-  assert(omeRoot.path.endsWith("/"))
-
+fun parseOmeXmlMetadata(omeRoot: Path): OMEXMLMetadata {
   val xml = readOmeXml(omeRoot.resolve("METADATA.ome.xml"))
 
   val service = ServiceFactory().getInstance(OMEXMLService::class.java)
@@ -35,11 +32,9 @@ fun parseOmeXmlMetadata(omeRoot: URI): OMEXMLMetadata {
 }
 
 
-fun readOmeXml(uri: URI): String {
-  val metadataFilePath = uri.toPath()
-
+fun readOmeXml(metadataFile: Path): String {
   val omeDocument = try {
-    val measurement = RandomAccessInputStream(metadataFilePath.absolutePathString())
+    val measurement = RandomAccessInputStream(metadataFile.absolutePathString())
     XMLTools.parseDOM(measurement)
   } catch (e: ParserConfigurationException) {
     throw IOException(e)

--- a/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeZarrUtils.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeZarrUtils.kt
@@ -1,10 +1,14 @@
 package dimilab.qupath.ext.cloud_omezarr
 
 import com.bc.zarr.ZarrArray
+import dimilab.qupath.ext.cloud_omezarr.OmeZarrUtils.Companion.logger
 import org.slf4j.Logger
-import qupath.lib.color.ColorModelFactory
 import qupath.lib.images.servers.PixelType
 import java.awt.image.*
+import java.net.URI
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import java.nio.file.ProviderNotFoundException
 import ome.xml.model.enums.PixelType as OmePixelType
 
 class OmeZarrUtils {
@@ -105,4 +109,22 @@ fun renderZarrToBufferedImage(
   }
 
   return BufferedImage(colorModel, raster, false, null)
+}
+
+fun getZarrRoot(uri: URI): Path {
+  val zarrFs = try {
+    FileSystems.getFileSystem(uri.resolve("/"))
+  } catch (e: ProviderNotFoundException) {
+    logger.error("No file system provider found for scheme {}, uri {}", uri.scheme, uri, e)
+    throw IllegalArgumentException("Unsupported scheme '${uri.scheme}'")
+  }
+
+  // As a convenience, if the URI ends with .zattrs, we use the parent directory as the root.
+  // In some applications it's hard to select a directory, so this lets the user select the file instead.
+  if (uri.path.endsWith("/.zattrs")) {
+    logger.info("Zarr root is .zattrs, using directory instead")
+    return zarrFs.getPath(uri.resolve("./").path)
+  }
+
+  return zarrFs.getPath(uri.path)
 }

--- a/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeZarrUtils.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeZarrUtils.kt
@@ -115,7 +115,7 @@ fun getZarrRoot(uri: URI): Path {
   val zarrFs = try {
     FileSystems.getFileSystem(uri.resolve("/"))
   } catch (e: ProviderNotFoundException) {
-    logger.error("No file system provider found for scheme {}, uri {}", uri.scheme, uri, e)
+    logger.error("No java.nio FileSystemProvider found for scheme '{}', uri: {}", uri.scheme, uri, e)
     throw IllegalArgumentException("Unsupported scheme '${uri.scheme}'")
   }
 

--- a/src/test/kotlin/dimilab/qupath/ext/cloud_omezarr/CloudOmeZarrServerTest.kt
+++ b/src/test/kotlin/dimilab/qupath/ext/cloud_omezarr/CloudOmeZarrServerTest.kt
@@ -25,7 +25,16 @@ class CloudOmeZarrServerTest {
     assertEquals(8, server.getDownsampleForResolution(3).roundToInt())
 
     assertEquals(8, server.nChannels())
-    val names = listOf("PDL1 (Opal 520)", "CD8 (Opal 540)", "FoxP3 (Opal 570)", "CD68 (Opal 620)", "PD1 (Opal 650)", "CK (Opal 690)", "DAPI", "Autofluorescence")
+    val names = listOf(
+      "PDL1 (Opal 520)",
+      "CD8 (Opal 540)",
+      "FoxP3 (Opal 570)",
+      "CD68 (Opal 620)",
+      "PD1 (Opal 650)",
+      "CK (Opal 690)",
+      "DAPI",
+      "Autofluorescence"
+    )
     assertEquals(names, (0 until server.nChannels()).map { server.getChannel(it).name })
 
     assertEquals(PixelType.FLOAT32, server.pixelType)

--- a/src/test/kotlin/dimilab/qupath/ext/cloud_omezarr/CloudOmeZarrServerTest.kt
+++ b/src/test/kotlin/dimilab/qupath/ext/cloud_omezarr/CloudOmeZarrServerTest.kt
@@ -1,12 +1,23 @@
 package dimilab.qupath.ext.cloud_omezarr
 
+import com.google.cloud.storage.BlobId
+import com.google.cloud.storage.BlobInfo
+import com.google.cloud.storage.StorageOptions
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
+import io.mockk.every
+import io.mockk.mockkStatic
 import junit.framework.TestCase.assertEquals
 import qupath.lib.images.servers.PixelType
+import java.net.URI
+import java.nio.file.Files
+import kotlin.io.path.isDirectory
+import kotlin.io.path.relativeTo
+import kotlin.io.path.toPath
 import kotlin.math.roundToInt
 import kotlin.test.Test
 
 class CloudOmeZarrServerTest {
-  val testZarrRootUri = CloudOmeZarrServer::class.java.classLoader.getResource("test.zarr/")?.toURI()
+  private val testZarrRootUri = CloudOmeZarrServer::class.java.classLoader.getResource("test.zarr/")?.toURI()
     ?: throw IllegalStateException("Could not find test.zarr")
 
   @Test
@@ -38,6 +49,37 @@ class CloudOmeZarrServerTest {
     assertEquals(names, (0 until server.nChannels()).map { server.getChannel(it).name })
 
     assertEquals(PixelType.FLOAT32, server.pixelType)
+  }
+
+  @Test
+  fun testGcsUri() {
+    val fakeStorageOptions = LocalStorageHelper.getOptions()
+    val fakeStorage = fakeStorageOptions.service
+    // Forward every file in the testZarrRootUri folders to the fakeStorage
+    val testRoot = testZarrRootUri.toPath()
+    Files.find(testRoot, 10, { path, _ -> !path.isDirectory() })
+      .forEach { path ->
+        val relativePath = path.relativeTo(testRoot)
+        val targetBlob = BlobId.of("test-bucket", "test-image.zarr/${relativePath.toString()}")
+        println("Storing $relativePath as $targetBlob")
+        val blobInfo = BlobInfo.newBuilder(targetBlob).build()
+        fakeStorage.create(blobInfo, Files.readAllBytes(path))
+      }
+
+    mockkStatic(StorageOptions::getDefaultInstance)
+    every { StorageOptions.getDefaultInstance() } returns fakeStorageOptions
+
+    val server = CloudOmeZarrServer(
+      zarrBaseUri = URI.create("gs://test-bucket/test-image.zarr/")
+    )
+
+    assertEquals(1401, server.width)
+    assertEquals(1050, server.height)
+
+    val result = server.readRegion(1.0, 0, 0, 101, 102)
+    assertEquals(101, result.width)
+    assertEquals(102, result.height)
+    assertEquals(8, result.raster.numBands)
   }
 
   @Test

--- a/src/test/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeXmlUtilsTest.kt
+++ b/src/test/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeXmlUtilsTest.kt
@@ -1,5 +1,6 @@
 package dimilab.qupath.ext.cloud_omezarr
 
+import kotlin.io.path.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -9,8 +10,8 @@ class OmeXmlUtilsTest {
 
   @Test
   fun testOmeChannelsToQuPath() {
-    val omeBaseUri = testZarrRootUri.resolve("OME/")
-    val omeZarrMetadata = parseOmeXmlMetadata(omeBaseUri)
+    val omeBase = testZarrRootUri.resolve("OME/").toPath()
+    val omeZarrMetadata = parseOmeXmlMetadata(omeBase)
     val channels = omeChannelsToQuPath(omeZarrMetadata)
 
     assert(channels.size == 8)

--- a/src/test/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeZarrUtilsTest.kt
+++ b/src/test/kotlin/dimilab/qupath/ext/cloud_omezarr/OmeZarrUtilsTest.kt
@@ -1,0 +1,42 @@
+package dimilab.qupath.ext.cloud_omezarr
+
+import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem
+import java.net.URI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class OmeZarrUtilsTest {
+  @Test
+  fun getZarrRoot_file() {
+    val uri = URI.create("file:///folder/animage.zarr/")
+    val zarrRoot = getZarrRoot(uri)
+    assertEquals("file", zarrRoot.fileSystem.provider().scheme)
+    assertEquals("/folder/animage.zarr", zarrRoot.toString())
+  }
+
+  @Test
+  fun getZarrRoot_gs() {
+    val uri = URI.create("gs://a-bucket/folder/animage.zarr/")
+    val zarrRoot = getZarrRoot(uri)
+    assertEquals("gs", zarrRoot.fileSystem.provider().scheme)
+    assertIs<CloudStorageFileSystem>(zarrRoot.fileSystem)
+    assertEquals("a-bucket", (zarrRoot.fileSystem as CloudStorageFileSystem).bucket())
+    assertEquals("/folder/animage.zarr/", zarrRoot.toString())
+  }
+
+  @Test
+  fun getZarrRoot_unsupported() {
+    val uri = URI.create("s3://a-bucket/folder/animage.zarr/")
+    val exception = kotlin.runCatching { getZarrRoot(uri) }.exceptionOrNull()
+    assertIs<IllegalArgumentException>(exception)
+    assertEquals("Unsupported scheme 's3'", exception?.message)
+  }
+
+  @Test
+  fun getZarrRoot_zattrs() {
+    val uri = URI.create("gs://a-bucket/folder/animage.zarr/.zattrs")
+    val zarrRoot = getZarrRoot(uri)
+    assertEquals("/folder/animage.zarr/", zarrRoot.toString())
+  }
+}


### PR DESCRIPTION
This PR switches to `Path` (vs `URI`) to leverage the `FileSystem` mechanism (a uniform interface into reading files from different locations).

Then we use Google's `java.nio` extension to provide a cloud storage file system.

This allows opening OME-Zarr images stored on GCS 😎 