### PR TITLE
Read OME-Zarr channels in parallel

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
 
 dependencies {
   implementation(kotlin("stdlib-jdk8"))
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
 
   implementation("net.java.dev.jna:jna:5.16.0")
 


### PR DESCRIPTION
To improve performance, let's read the channels in parallel. We know that the OME-Zarr separates the channels into separate directory structures, so we can fetch these in parallel.

We may still be inefficiently reading the tiles within each channel. Right now, it just reads the file using the file system provider (we use Google's cloud storage file system extension). That probably means we read the tiles blocking in serial.

Related to #7 