### PR TITLE
Support remote qpdata files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,9 +49,10 @@ dependencies {
   implementation("org.openmicroscopy:ome-model:6.4.0")
   implementation("dev.zarr:jzarr:0.4.2")
 
-  // Google Cloud Storage NIO filesystem
-  implementation(platform("com.google.cloud:libraries-bom:23.0.0"))
+  // Google Cloud Storage
+  implementation(platform("com.google.cloud:libraries-bom:26.43.0"))
   implementation("com.google.cloud:google-cloud-nio")
+  implementation("com.google.cloud:google-cloud-storage")
 
   // For testing
   testImplementation(libs.bundles.qupath)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
   implementation(kotlin("stdlib-jdk8"))
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
 
+  // For loading cblosc
   implementation("net.java.dev.jna:jna:5.16.0")
 
   // Main dependencies for most QuPath extensions
@@ -53,6 +54,10 @@ dependencies {
   implementation(platform("com.google.cloud:libraries-bom:26.43.0"))
   implementation("com.google.cloud:google-cloud-nio")
   implementation("com.google.cloud:google-cloud-storage")
+
+  // Other / utility
+  implementation("commons-cli:commons-cli:1.9.0")
+  implementation("commons-io:commons-io:2.16.1")
 
   // For testing
   testImplementation(libs.bundles.qupath)

--- a/src/main/java/dimilab/qupath/ext/omezarr/ui/InterfaceController.java
+++ b/src/main/java/dimilab/qupath/ext/omezarr/ui/InterfaceController.java
@@ -14,7 +14,7 @@ import java.util.ResourceBundle;
  * Controller for UI pane contained in interface.fxml
  */
 public class InterfaceController extends VBox {
-    private static final ResourceBundle resources = ResourceBundle.getBundle("dimilab.qupath.ext.cloud_omezarr.ui.strings");
+    private static final ResourceBundle resources = ResourceBundle.getBundle("dimilab.qupath.ext.omezarr.ui.strings");
 
     @FXML
     private Spinner<Integer> integerOptionSpinner;

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrExtension.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrExtension.kt
@@ -1,16 +1,14 @@
 package dimilab.qupath.ext.omezarr
 
-import dimilab.qupath.ext.omezarr.ui.InterfaceController
 import javafx.beans.property.BooleanProperty
 import javafx.beans.property.Property
 import javafx.event.ActionEvent
 import javafx.event.EventHandler
-import javafx.scene.Scene
+import javafx.scene.control.Alert
+import javafx.scene.control.ButtonType
 import javafx.scene.control.MenuItem
-import javafx.stage.Stage
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import qupath.fx.dialogs.Dialogs
 import qupath.fx.prefs.controlsfx.PropertyItemBuilder
 import qupath.lib.common.Version
 import qupath.lib.gui.QuPathGUI
@@ -18,8 +16,10 @@ import qupath.lib.gui.extensions.GitHubProject
 import qupath.lib.gui.extensions.GitHubProject.GitHubRepo
 import qupath.lib.gui.extensions.QuPathExtension
 import qupath.lib.gui.prefs.PathPrefs
-import java.io.IOException
 import java.util.*
+import java.util.function.Consumer
+import java.util.function.Predicate
+
 
 class CloudOmeZarrExtension : QuPathExtension, GitHubProject {
 
@@ -27,12 +27,16 @@ class CloudOmeZarrExtension : QuPathExtension, GitHubProject {
     val logger: Logger = LoggerFactory.getLogger(CloudOmeZarrExtension::class.java)
 
     val resources: ResourceBundle = ResourceBundle.getBundle("dimilab.qupath.ext.omezarr.ui.strings")
+
     // Display name
     val EXTENSION_NAME: String = resources.getString("name")
+
     // Short description
     val EXTENSION_DESCRIPTION: String = resources.getString("description")
+
     // Expected QuPath version
     val EXTENSION_QUPATH_VERSION: Version = Version.parse("v0.5.0")
+
     // GitHub repo for updates
     val EXTENSION_REPOSITORY: GitHubRepo = GitHubRepo.create(
       EXTENSION_NAME, "dimi-lab", "qupath-extension-cloud-omezarr"
@@ -70,11 +74,6 @@ class CloudOmeZarrExtension : QuPathExtension, GitHubProject {
     return integerOption
   }
 
-  /**
-   * Create a stage for the extension to display
-   */
-  private var stage: Stage? = null
-
   override fun installExtension(qupath: QuPathGUI) {
     if (isInstalled) {
       logger.debug("{} is already installed", name)
@@ -110,30 +109,40 @@ class CloudOmeZarrExtension : QuPathExtension, GitHubProject {
    */
   private fun addMenuItem(qupath: QuPathGUI) {
     val menu = qupath.getMenu("Extensions>$EXTENSION_NAME", true)
-    val menuItem = MenuItem("OME-Zarr menu item")
-    menuItem.onAction = EventHandler { _: ActionEvent? -> createStage() }
-    menuItem.disableProperty().bind(enableExtensionProperty.not())
-    menu.items.add(menuItem)
+
+    val refreshPathObjectsMenuItem = MenuItem("Refresh remote PathObjects")
+    refreshPathObjectsMenuItem.onAction = EventHandler { _: ActionEvent? -> createRefreshRemotePathObjectsStage() }
+    refreshPathObjectsMenuItem.disableProperty().bind(enableExtensionProperty.not())
+    menu.items.add(refreshPathObjectsMenuItem)
   }
 
   /**
    * Demo showing how to create a new stage with a JavaFX FXML interface.
    */
-  private fun createStage() {
-    if (stage == null) {
-      try {
-        stage = Stage()
-        val scene = Scene(InterfaceController.createInstance())
-        stage!!.initOwner(QuPathGUI.getInstance().stage)
-        stage!!.title = resources.getString("stage.title")
-        stage!!.scene = scene
-        stage!!.isResizable = false
-      } catch (e: IOException) {
-        Dialogs.showErrorMessage(resources.getString("error"), resources.getString("error.gui-loading-failed"))
-        logger.error("Unable to load extension interface FXML", e)
-      }
+  private fun createRefreshRemotePathObjectsStage() {
+    val dialog = Alert(
+      Alert.AlertType.CONFIRMATION,
+      "Delete all local path objects and refresh from server?"
+    )
+    dialog.showAndWait()
+      .filter(Predicate { response: ButtonType? -> response == ButtonType.OK })
+      .ifPresent(Consumer { response: ButtonType? -> doRefreshRemotePathObjects() })
+  }
+
+  private fun doRefreshRemotePathObjects() {
+    val imageData = QuPathGUI.getInstance().imageData
+    val server = imageData.server
+    if (server !is CloudOmeZarrServer) {
+      logger.error("Image server is not a CloudOmeZarrServer")
+      return
     }
-    stage!!.show()
+
+    // TODO: move this to a background thread, and add a spinner?
+
+    logger.info("Refreshing remote path objects from server: $server; ${server.getImageArgs().remoteQpDataPath}")
+    imageData.hierarchy.clearAll()
+    imageData.hierarchy.addObjects(server.readPathObjects())
+    logger.info("Path objects refreshed")
   }
 
 

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
@@ -250,15 +250,17 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
     }
 
     logger.info("Reading image data from remote path: ${serverArgs.remoteQpDataPath}")
-
+    val startTime = System.currentTimeMillis()
     val downloads = downloadUrisToTemp(listOf(serverArgs.remoteQpDataPath))
+    logger.info("Downloaded remote path in ${System.currentTimeMillis() - startTime} ms")
     val localPath = downloads[serverArgs.remoteQpDataPath] ?: throw IOException("Failed to download remote path")
 
     val imageData = PathIO.readImageData<BufferedImage>(localPath, null, this, null)
+    val objects = imageData.hierarchy.rootObject.childObjects.toMutableList()
 
-    logger.info("Image data read; extracting hierarchy root object")
+    logger.info("Image data read; extracting {} root objects", objects.size)
 
-    return imageData.hierarchy.rootObject.childObjects.toMutableList()
+    return objects
   }
 
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
@@ -128,6 +128,10 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
     )
   }
 
+  fun getImageArgs(): OmeZarrArgs {
+    return serverArgs
+  }
+
   override fun close() {
     zarrRoot.fileSystem.close()
     super.close()

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
@@ -72,7 +72,7 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
     val channels = omeChannelsToQuPath(omeMetadata)
 
     val omePixelType = omeMetadata.getPixelsType(0)
-    checkPixelType(omePixelType, omeMetadata.getPixelsBigEndian(0), scaleLevels)
+    checkPixelType(omePixelType, scaleLevels)
     val pixelType = omeXmlPixelTypeToQupath(omePixelType)
     colorModel = ColorModelFactory.createColorModel(pixelType, channels)
     logger.info("Pixel type: $pixelType; channels: ${channels.size}")

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudStorageUtils.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudStorageUtils.kt
@@ -1,0 +1,80 @@
+package dimilab.qupath.ext.omezarr
+
+import com.google.cloud.storage.BlobId
+import com.google.cloud.storage.BlobInfo
+import com.google.cloud.storage.transfermanager.ParallelDownloadConfig
+import com.google.cloud.storage.transfermanager.TransferManagerConfig
+import com.google.cloud.storage.transfermanager.TransferStatus
+import dimilab.qupath.ext.omezarr.CloudStorageUtils.Companion.logger
+import org.apache.commons.io.FileUtils
+import org.slf4j.Logger
+import java.io.File
+import java.io.IOException
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+
+class CloudStorageUtils {
+  companion object {
+    val logger: Logger = org.slf4j.LoggerFactory.getLogger(CloudStorageUtils::class.java)
+  }
+}
+
+fun downloadUrisToTemp(uris: List<URI>): Map<URI, Path> {
+  val transferManager = TransferManagerConfig
+    .newBuilder()
+    .setAllowDivideAndConquerDownload(true)
+    .build()
+    .service
+
+  val remoteBlobs = uris.map { uri ->
+    if (uri.scheme != "gs") {
+      throw IllegalArgumentException("Unsupported scheme '${uri.scheme}'")
+    }
+    val blobId = BlobId.fromGsUtilUri(uri.toString())
+    BlobInfo.newBuilder(blobId).build()
+  }
+
+  val bucket = remoteBlobs.first().bucket
+
+  if (remoteBlobs.any { it.bucket != bucket }) {
+    throw IllegalArgumentException("All URIs must be in the same bucket")
+  }
+
+  val getRoot = { b: BlobInfo -> b.name.substringBeforeLast("/") + "/" }
+
+  val remoteRoot = getRoot(remoteBlobs.first())
+  if (remoteBlobs.any { getRoot(it) != remoteRoot }) {
+    throw IllegalArgumentException("All URIs must share the same prefix directories")
+  }
+
+  val localRoot = Files.createTempDirectory("qupath-cloudomezarr")
+  Runtime.getRuntime().addShutdownHook(Thread { FileUtils.forceDelete(localRoot.toFile()) })
+
+  logger.info("Downloading {} blobs to {}: {}", remoteBlobs.size, localRoot, remoteBlobs)
+
+  val results = transferManager.use {
+    val downloadConfig = ParallelDownloadConfig
+      .newBuilder()
+      .setBucketName(bucket)
+      .setDownloadDirectory(localRoot)
+      .setStripPrefix(remoteRoot)
+      .build()
+    it.downloadBlobs(remoteBlobs, downloadConfig).downloadResults
+  }
+
+  results.forEach {
+    require(it.status == TransferStatus.SUCCESS) {
+      "Failed to download blob ${it.input.name} with status ${it.exception}"
+    }
+  }
+
+  return uris.associateWith {
+    val filename = File(it.path).name
+    val localPath = localRoot.resolve(filename)
+    localPath.exists() || throw IOException("Expected remote path $it to be at local path $localPath")
+
+    localPath
+  }
+}

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/OmeZarrUtils.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/OmeZarrUtils.kt
@@ -8,7 +8,6 @@ import org.slf4j.Logger
 import qupath.lib.images.servers.PixelType
 import java.awt.image.*
 import java.net.URI
-import java.nio.ByteOrder
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Path
@@ -37,7 +36,6 @@ fun omeXmlPixelTypeToZarrDtype(omeXmlPixelType: OmePixelType): com.bc.zarr.DataT
 
 fun checkPixelType(
   omePixelType: OmePixelType,
-  omeBigEndian: Boolean,
   scaleLevels: List<CloudOmeZarrServer.ScaleLevel>,
 ) {
   // This checks that the OME metadata and zarr were generated together correctly.
@@ -47,13 +45,6 @@ fun checkPixelType(
     if (zarrDtype != omeXmlPixelTypeToZarrDtype(omePixelType)) {
       throw IllegalArgumentException(
         "Zarr dtype ${zarrDtype.name} does not match OME XML pixel type ${omePixelType.name} for scale level ${scaleLevel.path}"
-      )
-    }
-
-    val zarrBigEndian = scaleLevel.zarrArray.byteOrder == ByteOrder.BIG_ENDIAN
-    if (omeBigEndian != zarrBigEndian) {
-      throw IllegalArgumentException(
-        "Zarr bigendian=${scaleLevel.zarrArray.byteOrder} does not match OME XML bigendian=$omeBigEndian for scale level ${scaleLevel.path}"
       )
     }
   }

--- a/src/main/resources/dimilab/qupath/ext/omezarr/ui/interface.fxml
+++ b/src/main/resources/dimilab/qupath/ext/omezarr/ui/interface.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.layout.*?>
 
 <?import javafx.geometry.Insets?>
-<fx:root type="VBox" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" xmlns="http://javafx.com/javafx/20" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root type="VBox" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" xmlns="http://javafx.com/javafx/20" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dimilab.qupath.ext.omezarr.ui.InterfaceController">
     <VBox spacing="5" alignment="CENTER_RIGHT">
         <padding>
             <Insets topRightBottomLeft="3"/>

--- a/src/test/kotlin/dimilab/qupath/ext/omezarr/OmeZarrUtilsTest.kt
+++ b/src/test/kotlin/dimilab/qupath/ext/omezarr/OmeZarrUtilsTest.kt
@@ -26,6 +26,17 @@ class OmeZarrUtilsTest {
   }
 
   @Test
+  fun getZarrRoot_gs_underscore() {
+    // Bucket names with underscores need special treatment…
+    val uri = URI.create("gs://a_bucket/folder/animage.zarr/")
+    val zarrRoot = getZarrRoot(uri)
+    assertEquals("gs", zarrRoot.fileSystem.provider().scheme)
+    assertIs<CloudStorageFileSystem>(zarrRoot.fileSystem)
+    assertEquals("a_bucket", (zarrRoot.fileSystem as CloudStorageFileSystem).bucket())
+    assertEquals("/folder/animage.zarr/", zarrRoot.toString())
+  }
+
+  @Test
   fun getZarrRoot_unsupported() {
     val uri = URI.create("s3://a-bucket/folder/animage.zarr/")
     val exception = kotlin.runCatching { getZarrRoot(uri) }.exceptionOrNull()


### PR DESCRIPTION
This adds menu items to manually sync the image hierarchy (annotations + detection objects) to & from cloud storage.

While it prompts the user for confirmation this is otherwise a sharp edge. It will save to remote no matter what, even if the local copy was out of date wrt the remote.

It takes approx 7s to download/upload a ~250 MB file for the test data, ~139M px, ~125k objects.
It takes approx 7s to write it back.

Test scenario;
* I created:
  * 1 rectangular annotation.
  * 1 freeform annotation.
  * 1 rectangular annotation, then deleted everything inside it.
* I resolved the hierarchy.
* I saved to server.
* I reopened the image, without the saved changes.
* I refreshed from server.
* I observed that the annotation hierarchy created above was loaded.

<img width="1167" alt="Screenshot 2025-04-23 at 11 24 57 PM" src="https://github.com/user-attachments/assets/b3cae045-05f7-4efa-971b-099ad46135ec" />

<img width="376" alt="Screenshot 2025-04-23 at 11 10 25 PM" src="https://github.com/user-attachments/assets/f274dff4-e1d9-4925-b00d-8180bfce9671" />
