### PR TITLE
Don't assume forward slash before gs:/

### DIFF
--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServerBuilder.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServerBuilder.kt
@@ -19,7 +19,7 @@ class CloudOmeZarrServerBuilder : ImageServerBuilder<BufferedImage> {
       return null
     }
 
-    val effectiveUri = if (uri.scheme == "file" && uri.path.contains("/gs:/")) {
+    val effectiveUri = if (uri.scheme == "file" && uri.path.contains("gs:/")) {
       val new = URI.create("gs://${uri.path.substringAfter("gs:/")}")
       logger.info("Converted file URI to GCS: $new; scheme: ${new.scheme}, path: ${new.path}")
       new

--- a/src/test/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServerBuilderTest.kt
+++ b/src/test/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServerBuilderTest.kt
@@ -6,6 +6,7 @@ import com.google.cloud.storage.StorageOptions
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
 import io.mockk.every
 import io.mockk.mockkStatic
+import java.io.File
 import java.net.URI
 import java.nio.file.Files
 import kotlin.io.path.isDirectory
@@ -43,7 +44,8 @@ class CloudOmeZarrServerBuilderTest {
     }
 
     // Test with a Windows munged URI
-    builder.checkImageSupport(URI.create("file:/C:/some-folder/gs:/a-bucket/a-folder/test.zarr")).let {
+    val windowsFile = File("C:\\some-folder\\gs:/a-bucket/a-folder/test.zarr")
+    builder.checkImageSupport(windowsFile.toURI()).let {
       assertNotNull(it)
       assertEquals(5f, it.supportLevel)
       assertEquals("gs://a-bucket/a-folder/test.zarr", it.builders.first().urIs.first().toString())


### PR DESCRIPTION
On Windows, it looks like we may actually get a backslash before gs:/. This checks out as it seems to be using the gs://bucket/file format as a relative path, turning it into:

```
file:/C:\working-directory\gs:/bucket/file.
```

So let's just test for gs:/ not whatever character comes in before.

All this is due to this code (I think) :

https://github.com/qupath/qupath/blob/4f53be759c1858f92aeb396741a1fc60161bbe3f/qupath-core/src/main/java/qupath/lib/images/servers/ImageServerProvider.java#L140

Since a gs:// url doesn't start with file or http, the code treats it as a regular path.

Let's hope this fixes it …