### PR TITLE
Handle metadata without explicit channel names

### DIFF
--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/OmeXmlUtils.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/OmeXmlUtils.kt
@@ -71,7 +71,7 @@ fun randomColor(): Color {
 
 fun omeChannelsToQuPath(omeMetadata: OMEXMLMetadata): List<ImageChannel> {
   return (0 until omeMetadata.getChannelCount(0)).map { channelNum ->
-    val name = omeMetadata.getChannelName(0, channelNum)
+    val name = omeMetadata.getChannelName(0, channelNum) ?: "Channel $channelNum"
     val color = omeMetadata.getChannelColor(0, channelNum).let {
       if (it == null) {
         logger.warn("Channel $channelNum has no color set in OME XML metadata; picking randomly")

--- a/src/test/kotlin/dimilab/qupath/ext/omezarr/OmeXmlUtilsTest.kt
+++ b/src/test/kotlin/dimilab/qupath/ext/omezarr/OmeXmlUtilsTest.kt
@@ -8,6 +8,9 @@ class OmeXmlUtilsTest {
   private val testZarrRootUri = CloudOmeZarrServer::class.java.classLoader.getResource("test.zarr/")?.toURI()
     ?: throw IllegalStateException("Could not find test.zarr")
 
+  private val testOmeMetadataRootUri = CloudOmeZarrServer::class.java.classLoader.getResource("test-ome-metadata/")?.toURI()
+    ?: throw IllegalStateException("Could not find test-ome-metadata")
+
   @Test
   fun testOmeChannelsToQuPath() {
     val omeBase = testZarrRootUri.resolve("OME/").toPath()
@@ -32,5 +35,18 @@ class OmeXmlUtilsTest {
     assertEquals(0xFF0000FF.toInt(), channels[6].color)
     assertEquals("Autofluorescence", channels[7].name)
     assertEquals(0xFF000000.toInt(), channels[7].color)
+  }
+
+  @Test
+  fun testOmeChannelsToQuPathMissingNames() {
+    val omeBase = testOmeMetadataRootUri.resolve("missing-channel-names/").toPath()
+    val omeZarrMetadata = parseOmeXmlMetadata(omeBase)
+    val channels = omeChannelsToQuPath(omeZarrMetadata)
+
+    assertEquals(channels.size, 3)
+
+    assertEquals("Channel 0", channels[0].name)
+    assertEquals("Channel 1 Is Present", channels[1].name)
+    assertEquals("Channel 2", channels[2].name)
   }
 }

--- a/src/test/resources/test-ome-metadata/missing-channel-names/METADATA.ome.xml
+++ b/src/test/resources/test-ome-metadata/missing-channel-names/METADATA.ome.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     Creator="OME Bio-Formats 7.0.1" UUID="urn:uuid:12345678-1234-1234-1234-123456789012"
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+    <Image ID="Image:0">
+        <Pixels BigEndian="true" DimensionOrder="XYZCT" ID="Pixels:0" Interleaved="false" PhysicalSizeX="0.2201"
+                PhysicalSizeXUnit="µm" PhysicalSizeY="0.2201" PhysicalSizeYUnit="µm" SignificantBits="8" SizeC="3"
+                SizeT="1" SizeX="34" SizeY="41" SizeZ="1" Type="uint8">
+            <Channel ID="Channel:0:0" SamplesPerPixel="1">
+                <LightPath/>
+            </Channel>
+            <Channel ID="Channel:0:1" Name="Channel 1 Is Present" SamplesPerPixel="1">
+                <LightPath/>
+            </Channel>
+            <Channel ID="Channel:0:2" SamplesPerPixel="1">
+                <LightPath/>
+            </Channel>
+            <MetadataOnly/>
+        </Pixels>
+    </Image>
+    <StructuredAnnotations>
+        <MapAnnotation ID="Annotation:Resolution:0" Namespace="openmicroscopy.org/PyramidResolution">
+            <Value/>
+        </MapAnnotation>
+    </StructuredAnnotations>
+</OME>


### PR DESCRIPTION
When metadata doesn't have channel names, name it `Channel X` where x is the channel index (zero-indexed).

Fixes #34