### PR TITLE
Generate QuPath change events

### DIFF
--- a/src/main/kotlin/dimilab/qupath/Logging.kt
+++ b/src/main/kotlin/dimilab/qupath/Logging.kt
@@ -1,0 +1,25 @@
+package dimilab.qupath
+
+import ch.qos.logback.classic.Level
+
+object Logging {
+  private val logger = org.slf4j.LoggerFactory.getLogger(Logging::class.java)
+}
+
+fun <T> quietLoggers(vararg loggers: String, block: () -> T): T {
+  val loggerContext = org.slf4j.LoggerFactory.getILoggerFactory() as ch.qos.logback.classic.LoggerContext
+
+  val originalLevels = loggers.associateWith { logger -> loggerContext.getLogger(logger).level }
+
+  try {
+    loggers.forEach {
+      loggerContext.getLogger(it).level = Level.ERROR
+    }
+    return block()
+  } finally {
+    originalLevels.forEach { (name, level) ->
+      val logger = loggerContext.getLogger(name)
+      logger.level = level
+    }
+  }
+}

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncer.kt
@@ -1,0 +1,93 @@
+package dimilab.qupath.ext.omezarr
+
+import dimilab.qupath.pathobjects.ChangeTracker
+import dimilab.qupath.pathobjects.Event
+import qupath.lib.gui.viewer.QuPathViewer
+import qupath.lib.gui.viewer.QuPathViewerListener
+import qupath.lib.images.ImageData
+import qupath.lib.objects.PathObject
+import qupath.lib.objects.hierarchy.PathObjectHierarchy
+import qupath.lib.objects.hierarchy.events.PathObjectHierarchyEvent
+import qupath.lib.objects.hierarchy.events.PathObjectHierarchyEvent.HierarchyEventType
+import qupath.lib.objects.hierarchy.events.PathObjectHierarchyListener
+import java.awt.Shape
+import java.awt.image.BufferedImage
+
+// This bridges qupath hierarchy events into our change tracking.
+class AnnotationSyncer : QuPathViewerListener, PathObjectHierarchyListener {
+  companion object {
+    private val logger = org.slf4j.LoggerFactory.getLogger(AnnotationSyncer::class.java)
+  }
+
+  var trackedHierarchy: PathObjectHierarchy? = null
+  val changeTracker = ChangeTracker()
+  val trackedChanges = mutableListOf<Event>()
+
+  var paused: Boolean = false
+
+  override fun imageDataChanged(
+    viewer: QuPathViewer?,
+    imageDataOld: ImageData<BufferedImage>?,
+    imageDataNew: ImageData<BufferedImage>?,
+  ) {
+    logger.info("imageDataChanged: retracking hierarchy")
+    trackedHierarchy?.removeListener(this)
+    trackedHierarchy = imageDataNew?.hierarchy.also {
+      changeTracker.retrack(it)
+      it?.addListener(this)
+    }
+  }
+
+  override fun hierarchyChanged(event: PathObjectHierarchyEvent?) {
+    if (paused) return
+    if (event == null) return
+
+    // Don't bother with changes that are still happening.
+    if (event.isChanging) return
+
+    // If we don't think we're tracking a hierarchy, complain loudly!
+    if (trackedHierarchy == null) {
+      logger.error("Received hierarchyChanged event but no hierarchy is being tracked!")
+      return
+    }
+
+    logger.info("Hierarchy change event: ${event.eventType}")
+
+    val changeEvents = when (event.eventType) {
+      HierarchyEventType.ADDED, HierarchyEventType.CHANGE_MEASUREMENTS, HierarchyEventType.CHANGE_CLASSIFICATION, HierarchyEventType.CHANGE_OTHER -> {
+        changeTracker.trackObjectChanges(event.changedObjects)
+      }
+      HierarchyEventType.REMOVED -> {
+        changeTracker.trackObjectDeletions(event.changedObjects)
+      }
+      HierarchyEventType.OTHER_STRUCTURE_CHANGE -> {
+        val newObjects = event.hierarchy.getAllObjects(false).associateBy { it.id }
+        changeTracker.trackBulkChanges(newObjects)
+      }
+      else -> {
+        logger.error("Don't know how to handle hierarchy change event: ${event.eventType}")
+        listOf()
+      }
+    }
+
+    logger.info("Detected ${changeEvents.size} changed hierarchy objects")
+
+    changeEvents
+      .groupBy { it.javaClass.name }
+      .forEach { (eventType, events) ->
+        logger.info("Changes of type $eventType: ${events.size}")
+      }
+
+    trackedChanges.addAll(changeEvents)
+  }
+
+  override fun visibleRegionChanged(viewer: QuPathViewer?, shape: Shape?) {
+  }
+
+  override fun selectedObjectChanged(viewer: QuPathViewer?, pathObjectSelected: PathObject?) {
+  }
+
+  override fun viewerClosed(viewer: QuPathViewer?) {
+  }
+
+}

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrExtension.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrExtension.kt
@@ -134,7 +134,7 @@ class CloudOmeZarrExtension : QuPathExtension, GitHubProject {
     )
     dialog.showAndWait()
       .filter(Predicate { response: ButtonType? -> response == ButtonType.OK })
-      .ifPresent(Consumer { response: ButtonType? -> doRefreshRemotePathObjects() })
+      .ifPresent(Consumer { _: ButtonType? -> doRefreshRemotePathObjects() })
   }
 
   private fun doRefreshRemotePathObjects() {
@@ -160,7 +160,7 @@ class CloudOmeZarrExtension : QuPathExtension, GitHubProject {
     )
     dialog.showAndWait()
       .filter(Predicate { response: ButtonType? -> response == ButtonType.OK })
-      .ifPresent(Consumer { response: ButtonType? -> doSaveToRemote() })
+      .ifPresent(Consumer { _: ButtonType? -> doSaveToRemote() })
   }
 
   private fun doSaveToRemote() {

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
@@ -2,6 +2,7 @@ package dimilab.qupath.ext.omezarr
 
 import com.bc.zarr.ZarrArray
 import com.bc.zarr.ZarrGroup
+import dimilab.qupath.quietLoggers
 import loci.formats.ome.OMEXMLMetadata
 import org.apache.commons.cli.*
 import qupath.lib.color.ColorModelFactory
@@ -255,11 +256,14 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
     logger.info("Downloaded remote path in ${System.currentTimeMillis() - startTime} ms")
     val localPath = downloads[serverArgs.remoteQpDataPath] ?: throw IOException("Failed to download remote path")
 
-    val imageData = PathIO.readImageData<BufferedImage>(localPath, null, this, null)
+    logger.debug("Opening image data from local path: $localPath")
+
+    val imageData = quietLoggers("qupath.lib.objects.MetadataMap") {
+      PathIO.readImageData<BufferedImage>(localPath, null, this, null)
+    }
+
     val objects = imageData.hierarchy.rootObject.childObjects.toMutableList()
-
-    logger.info("Image data read; extracting {} root objects", objects.size)
-
+    logger.info("Image data read; found {} objects at root", objects.size)
     return objects
   }
 

--- a/src/main/kotlin/dimilab/qupath/pathobjects/Changes.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/Changes.kt
@@ -1,0 +1,119 @@
+package dimilab.qupath.pathobjects
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import org.slf4j.LoggerFactory
+import qupath.lib.io.GsonTools
+import qupath.lib.objects.PathObject
+import java.time.Instant
+import java.util.*
+
+sealed class Event {
+  abstract val id: UUID
+  abstract val timestamp: Instant
+  abstract val eventType: String
+}
+
+data class CreateEvent(
+  override val id: UUID,
+  override val timestamp: Instant = Instant.now(),
+  // A JSON object mapping the created object's fields to their values
+  val fields: JsonObject,
+  override val eventType: String = "create",
+) : Event()
+
+data class EditEvent(
+  override val id: UUID,
+  override val timestamp: Instant = Instant.now(),
+  // A JSON object mapping the changed fields to their new values
+  val diff: JsonObject,
+  override val eventType: String = "edit",
+) : Event()
+
+data class DeleteEvent(
+  override val id: UUID,
+  override val timestamp: Instant = Instant.now(),
+  override val eventType: String = "delete",
+) : Event()
+
+object Generator {
+  private val logger = LoggerFactory.getLogger(Generator::class.java)
+  private val gson = GsonTools.getInstance()
+
+  fun makeCreateEvent(obj: PathObject): CreateEvent {
+    val newJson = gson.toJson(obj)
+    return CreateEvent(
+      id = obj.id,
+      timestamp = Instant.now(),
+      fields = gson.fromJson(newJson, JsonObject::class.java)
+    )
+  }
+
+  fun diffPathObjects(oldObject: JsonObject, newObject: JsonObject): Map<String, JsonElement> {
+    return newObject.entrySet().mapNotNull { (key, newValue) ->
+      val oldValue = oldObject.get(key)
+      if (oldValue != newValue) {
+        key to newValue
+      } else {
+        null
+      }
+    }.toMap()
+  }
+
+  fun makeEditEvent(newObj: PathObject, oldObj: PathObject?): EditEvent {
+    val newJson = gson.fromJson(gson.toJson(newObj), JsonObject::class.java)
+
+    val changes = oldObj?.let {
+      val oldJson = gson.fromJson(gson.toJson(it), JsonObject::class.java)
+      diffPathObjects(oldJson, newJson)
+    } ?: newJson.entrySet().associate { it.key to it.value }
+
+    return EditEvent(
+      id = newObj.id,
+      timestamp = Instant.now(),
+      diff = gson.toJsonTree(changes).asJsonObject,
+    )
+  }
+
+  fun generateChangeEvents(
+    trackedObjects: Map<UUID, PathObject>,
+    newObjects: Map<UUID, PathObject>,
+  ): List<Event> {
+    val events = mutableListOf<Event>()
+    val now = Instant.now()
+
+    // Find added objects
+    newObjects.forEach { (id, obj) ->
+      if (!trackedObjects.containsKey(id)) {
+        val newJson = gson.toJson(obj)
+        logger.trace("Found added object: {}", obj.javaClass)
+        events.add(
+          CreateEvent(
+            id = id,
+            timestamp = now,
+            fields = gson.fromJson(newJson, JsonObject::class.java)
+          )
+        )
+      }
+    }
+
+    // Find deleted and edited objects
+    trackedObjects.forEach { (id, oldObj) ->
+      val newObject = newObjects[id]
+
+      if (newObject == null) {
+        logger.trace("Found deleted object: {}", trackedObjects[id]?.javaClass)
+        events.add(DeleteEvent(id, now))
+      } else {
+        // Compare objects by converting them to JSON and comparing the trees
+        if (oldObj != newObject) {
+          logger.trace("Found modified object: {}", newObject.javaClass)
+
+          events.add(makeEditEvent(newObject, oldObj))
+        }
+      }
+    }
+
+    return events
+  }
+}

--- a/src/main/kotlin/dimilab/qupath/pathobjects/Changes.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/Changes.kt
@@ -4,7 +4,9 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import org.slf4j.LoggerFactory
 import qupath.lib.io.GsonTools
+import qupath.lib.objects.PathDetectionObject
 import qupath.lib.objects.PathObject
+import qupath.lib.objects.hierarchy.PathObjectHierarchy
 import java.time.Instant
 import java.util.*
 
@@ -36,11 +38,32 @@ data class DeleteEvent(
   override val eventType: String = "delete",
 ) : Event()
 
-object Generator {
-  private val logger = LoggerFactory.getLogger(Generator::class.java)
+class ChangeTracker {
+  private val logger = LoggerFactory.getLogger(ChangeTracker::class.java)
   private val gson = GsonTools.getInstance()
+  val trackedObjects = mutableMapOf<UUID, JsonObject>()
 
-  fun makeCreateEvent(id: UUID, newJson: JsonObject): CreateEvent {
+  fun retrack(newHierarchy: PathObjectHierarchy?) {
+    trackedObjects.clear()
+
+    if (newHierarchy == null) {
+      return
+    }
+
+    // The conversion to json should be parallelized… but,
+    // excluding detection objects makes it way faster!
+    newHierarchy.getAllObjects(false).forEach { pathObject ->
+      // We don't track detection object changes, so don't track anything beyond existence
+      if (pathObject is PathDetectionObject) {
+        trackedObjects[pathObject.id] = JsonObject() // just so we know it's there
+        return@forEach
+      }
+      trackedObjects[pathObject.id] = pathObject.toJsonObject()
+    }
+    logger.info("Now tracking ${trackedObjects.size} objects; hierarchy root is: ${newHierarchy.rootObject.id}")
+  }
+
+  private fun makeCreateEvent(id: UUID, newJson: JsonObject): CreateEvent {
     return CreateEvent(
       id = id,
       timestamp = Instant.now(),
@@ -48,7 +71,12 @@ object Generator {
     )
   }
 
-  fun makeEditEvent(id: UUID, oldJson: JsonObject, newJson: JsonObject, now: Instant = Instant.now()): EditEvent {
+  private fun makeEditEvent(
+    id: UUID,
+    oldJson: JsonObject,
+    newJson: JsonObject,
+    now: Instant = Instant.now(),
+  ): EditEvent {
     val changes = diffJsonObjects(oldJson, newJson)
 
     return EditEvent(
@@ -69,44 +97,88 @@ object Generator {
     }.toMap()
   }
 
-  // Generate a list of change events for two sets of objects, in bulk.
-  fun generateChangeEvents(
-    trackedObjects: Map<UUID, JsonObject>,
-    newObjects: Map<UUID, PathObject>,
-  ): List<Event> {
+  fun trackObjectChanges(pathObjects: Collection<PathObject>): List<Event> {
+    return pathObjects.map { pathObject ->
+      val oldJson = trackedObjects[pathObject.id]
+      val newJson = pathObject.toJsonObject()
+
+      trackedObjects[pathObject.id] = newJson
+
+      if (oldJson == null) {
+        logger.debug("Tracking object creation: {}", pathObject.id)
+        makeCreateEvent(pathObject.id, newJson)
+      } else {
+        logger.debug("Tracking object edit: {}", pathObject.id)
+        makeEditEvent(pathObject.id, oldJson, newJson)
+      }
+    }
+  }
+
+  fun trackObjectDeletions(pathObjects: Collection<PathObject>): List<Event> {
+    return pathObjects.map { pathObject ->
+      logger.debug("Tracking object deletion: {}", pathObject.id)
+      trackedObjects.remove(pathObject.id)
+      DeleteEvent(pathObject.id)
+    }
+  }
+
+  fun trackBulkChanges(newObjects: Map<UUID, PathObject>): List<Event> {
+    logger.info("Tracking bulk hierarchy change. Previously tracking: ${trackedObjects.size} objects. Now tracking: ${newObjects.size} objects")
     val events = mutableListOf<Event>()
     val now = Instant.now() // don't skew "now" for grouped events
+
+    val newJsons = mutableMapOf<UUID, JsonObject>()
 
     logger.debug("Finding added objects")
     newObjects.forEach { (id, obj) ->
       if (!trackedObjects.containsKey(id)) {
-        val newJson = gson.toJson(obj)
         logger.trace("Found added object: {}", obj.javaClass)
+        val newJson = obj.toJsonObject()
         events.add(
           CreateEvent(
             id = id,
             timestamp = now,
-            fields = gson.fromJson(newJson, JsonObject::class.java)
+            fields = newJson,
           )
         )
+        newJsons[id] = newJson
       }
     }
 
     logger.debug("Finding deleted & changed objects")
-    // This should probably be parallelized for large hierarchies
+    // This should perhaps be parallelized for large hierarchies
+    // But… excluding detection objects makes it way faster!
     trackedObjects.forEach { (id, oldJson) ->
       val newObject = newObjects[id]
 
       if (newObject == null) {
         logger.trace("Found deleted object: {}", trackedObjects[id]?.javaClass)
         events.add(DeleteEvent(id, now))
+      } else if (newObject.isRootObject) {
+        // No need to compare the root: we're comparing all the children!
+        return@forEach
+      } else if (newObject is PathDetectionObject) {
+        // As of QuPath 0.5.1, detection objects don't seem to get *edited* in bulk –
+        // but they do get deleted in bulk (handled above). Note that we don't track
+        // detection object changes at all.
+        return@forEach
       } else {
-        // Compare objects by converting them to JSON and comparing the trees
-        if (oldJson != newObject) {
+        val newJson = newObject.toJsonObject()
+        if (oldJson != newJson) {
           logger.trace("Found modified object: {}", newObject.javaClass)
 
           events.add(makeEditEvent(id, oldJson, newJson, now))
+          newJsons[id] = newJson
         }
+      }
+    }
+
+    // Handled separately to avoid modifying the map during iteration
+    events.forEach { event ->
+      when (event) {
+        is CreateEvent -> trackedObjects[event.id] = newJsons[event.id]!!
+        is EditEvent -> trackedObjects[event.id] = newJsons[event.id]!!
+        is DeleteEvent -> trackedObjects.remove(event.id)
       }
     }
 

--- a/src/main/kotlin/dimilab/qupath/pathobjects/Utils.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/Utils.kt
@@ -1,6 +1,10 @@
 package dimilab.qupath.pathobjects
 
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
 import qupath.lib.objects.PathObject
+import java.time.Instant
 
 
 fun PathObject.toJsonObject(): com.google.gson.JsonObject {
@@ -8,4 +12,19 @@ fun PathObject.toJsonObject(): com.google.gson.JsonObject {
   val gson = qupath.lib.io.GsonTools.getInstance()
   val jsonStr = gson.toJson(this)
   return gson.fromJson(jsonStr, com.google.gson.JsonObject::class.java)
+}
+
+class InstantTypeAdapter : TypeAdapter<Instant>() {
+  override fun write(out: JsonWriter, value: Instant?) {
+    if (value == null) {
+      out.nullValue()
+      return
+    }
+    out.value(value.toString())
+  }
+
+  override fun read(input: JsonReader): Instant? {
+    val str = input.nextString()
+    return if (str == null) null else Instant.parse(str)
+  }
 }

--- a/src/main/kotlin/dimilab/qupath/pathobjects/Utils.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/Utils.kt
@@ -1,0 +1,11 @@
+package dimilab.qupath.pathobjects
+
+import qupath.lib.objects.PathObject
+
+
+fun PathObject.toJsonObject(): com.google.gson.JsonObject {
+  // Is this truly the best way: going from object to string then parsed to JSON object?
+  val gson = qupath.lib.io.GsonTools.getInstance()
+  val jsonStr = gson.toJson(this)
+  return gson.fromJson(jsonStr, com.google.gson.JsonObject::class.java)
+}

--- a/src/test/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncerTest.kt
+++ b/src/test/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncerTest.kt
@@ -1,0 +1,47 @@
+package dimilab.qupath.ext.omezarr
+
+import dimilab.qupath.pathobjects.ChangesTest
+import qupath.lib.objects.PathObjects
+import qupath.lib.objects.hierarchy.PathObjectHierarchy
+import java.awt.image.BufferedImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+
+class AnnotationSyncerTest {
+  @Test
+  fun testHierarchyChanged() {
+    val syncer = AnnotationSyncer()
+    val hierarchy = PathObjectHierarchy()
+    val newData = qupath.lib.images.ImageData<BufferedImage>(null, hierarchy)
+    syncer.imageDataChanged(null, null, newData)
+
+    val annotation = PathObjects.createAnnotationObject(ChangesTest().roi1)
+    annotation.name = "initial"
+    hierarchy.addObject(annotation)
+
+    annotation.name = "second"
+    hierarchy.fireObjectsChangedEvent(this, listOf(annotation))
+
+    hierarchy.removeObject(annotation, false)
+
+    val events = syncer.trackedChanges
+    assertEquals(3, events.size)
+
+    val createEvent = events[0]
+    assertIs<dimilab.qupath.pathobjects.CreateEvent>(createEvent)
+    assert(createEvent.id == annotation.id)
+    assert(createEvent.fields["properties"].asJsonObject["name"].asString == "initial")
+
+    val editEvent = events[1]
+    assertIs<dimilab.qupath.pathobjects.EditEvent>(editEvent)
+    assert(editEvent.id == annotation.id)
+    assertEquals(setOf("properties"), editEvent.diff.keySet())
+    assert(editEvent.diff.get("properties").asJsonObject.get("name").asString == "second")
+
+    val deleteEvent = events[2]
+    assertIs<dimilab.qupath.pathobjects.DeleteEvent>(deleteEvent)
+    assert(deleteEvent.id == annotation.id)
+  }
+}

--- a/src/test/kotlin/dimilab/qupath/ext/omezarr/CloudZarrStoreTest.kt
+++ b/src/test/kotlin/dimilab/qupath/ext/omezarr/CloudZarrStoreTest.kt
@@ -7,8 +7,11 @@ import io.mockk.spyk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertContentEquals
+import kotlin.test.assertTrue
 import java.io.ByteArrayInputStream
 import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
@@ -154,7 +157,7 @@ class CloudZarrStoreTest {
     assertEquals(1, deferredThreadsCreated.get(), "Only one deferred thread should be created")
 
     // Verify that both threads got the same result
-    assertArrayEquals(
+    assertContentEquals(
       firstThreadResult.get(), secondThreadResult.get(),
       "Both threads should get the same content"
     )
@@ -172,17 +175,20 @@ class CloudZarrStoreTest {
       val secondThreadCompletedIndex = events.indexOf("Second thread completed")
 
       // Verify that the deferred thread completed after the second thread started
-      assert(secondThreadStartedIndex < deferredThreadCompletedIndex) {
+      assertTrue(
+        secondThreadStartedIndex < deferredThreadCompletedIndex,
         "Deferred thread should complete after the second thread starts"
-      }
+      )
 
       // Verify that both threads completed after the deferred thread completed
-      assert(deferredThreadCompletedIndex < firstThreadCompletedIndex) {
+      assertTrue(
+        deferredThreadCompletedIndex < firstThreadCompletedIndex,
         "First thread should complete after the deferred thread completes"
-      }
-      assert(deferredThreadCompletedIndex < secondThreadCompletedIndex) {
+      )
+      assertTrue(
+        deferredThreadCompletedIndex < secondThreadCompletedIndex,
         "Second thread should complete after the deferred thread completes"
-      }
+      )
     }
   }
 }

--- a/src/test/kotlin/dimilab/qupath/pathobjects/ChangesTest.kt
+++ b/src/test/kotlin/dimilab/qupath/pathobjects/ChangesTest.kt
@@ -1,0 +1,99 @@
+package dimilab.qupath.pathobjects
+
+import com.google.gson.JsonObject
+import dimilab.qupath.pathobjects.Generator.generateChangeEvents
+import qupath.lib.geom.Point2
+import qupath.lib.io.GsonTools
+import qupath.lib.objects.PathObjects
+import qupath.lib.regions.ImagePlane.getDefaultPlane
+import qupath.lib.roi.ROIs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ChangesTest {
+  val plane = getDefaultPlane()
+  val roi1 = ROIs.createRectangleROI(0.0, 0.0, 100.0, 100.0, plane)
+  val roi2 = ROIs.createRectangleROI(1.0, 2.0, 100.0, 100.0, plane)
+  private val gson = GsonTools.getInstance()
+
+  fun geometryToPoints(geomJson: JsonObject): List<Point2> {
+    val coordsList = geomJson["coordinates"].asJsonArray.first().asJsonArray
+    val coords = coordsList.map { pair ->
+      val doubles = pair.asJsonArray.map { it.asDouble }
+      Point2(doubles[0], doubles[1])
+    }
+
+    return coords
+  }
+
+  @Test
+  fun testDiffAnnotationRectangles() {
+    val po1 = PathObjects.createAnnotationObject(roi1)
+    po1.name = "po1"
+    val po2 = PathObjects.createAnnotationObject(roi2)
+    po2.name = "po2"
+    po2.id = po1.id
+
+    val oldJsonStr = gson.toJson(po1)
+    val newJsonStr = gson.toJson(po2)
+    val oldObject = gson.fromJson(oldJsonStr, JsonObject::class.java)
+    val newObject = gson.fromJson(newJsonStr, JsonObject::class.java)
+    val diffs = Generator.diffPathObjects(oldObject, newObject)
+
+    assertEquals(setOf("geometry", "properties"), diffs.keys)
+    diffs["geometry"]?.asJsonObject?.let { geomJson ->
+      val type = geomJson.get("type").asString
+      assertEquals("Polygon", type)
+      val coords = geometryToPoints(geomJson)
+      assertEquals(roi2.allPoints + roi2.allPoints[0], coords)
+    }
+
+    diffs["properties"]?.asJsonObject?.let { propsJson ->
+      val name = propsJson.get("name").asString
+      assertEquals("po2", name)
+    }
+  }
+
+  @Test
+  fun testGenerateChangeEvents() {
+    val changedObjOld = PathObjects.createAnnotationObject(roi2)
+    changedObjOld.name = "po1"
+    val changedObjNew = PathObjects.createAnnotationObject(roi1)
+    changedObjNew.name = "po2"
+    changedObjNew.id = changedObjOld.id
+
+    val deletedObj = PathObjects.createAnnotationObject(roi1)
+    deletedObj.name = "deleted_po"
+    val createdObj = PathObjects.createAnnotationObject(roi2)
+    createdObj.name = "added_po"
+
+    val oldTrackedObjects = mapOf(
+      changedObjOld.id to changedObjOld,
+      deletedObj.id to deletedObj
+    )
+    val newTrackedObjects = mapOf(
+      changedObjNew.id to changedObjNew,
+      createdObj.id to createdObj
+    )
+
+    val changes = generateChangeEvents(oldTrackedObjects, newTrackedObjects)
+    assertEquals(3, changes.size)
+
+    val editEvent = changes.find { it.eventType == "edit" }
+    assertIs<EditEvent>(editEvent)
+    assert(editEvent.id == changedObjOld.id)
+    val diff = editEvent.diff
+    assertEquals(roi1.allPoints + roi1.allPoints[0], geometryToPoints(diff.get("geometry").asJsonObject))
+    assertEquals(setOf("geometry", "properties"), diff.keySet())
+
+    val deleteEvent = changes.find { it.eventType == "delete" }
+    assertIs<DeleteEvent>(deleteEvent)
+    assert(deleteEvent.id == deletedObj.id)
+
+    val createEvent = changes.find { it.eventType == "create" }
+    assertIs<CreateEvent>(createEvent)
+    assert(createEvent.id == createdObj.id)
+    assertEquals(roi2.allPoints + roi2.allPoints[0], geometryToPoints(createEvent.fields.get("geometry").asJsonObject))
+  }
+}

--- a/src/test/kotlin/dimilab/qupath/pathobjects/ChangesTest.kt
+++ b/src/test/kotlin/dimilab/qupath/pathobjects/ChangesTest.kt
@@ -5,16 +5,18 @@ import dimilab.qupath.pathobjects.Generator.generateChangeEvents
 import qupath.lib.geom.Point2
 import qupath.lib.io.GsonTools
 import qupath.lib.objects.PathObjects
+import qupath.lib.regions.ImagePlane
 import qupath.lib.regions.ImagePlane.getDefaultPlane
 import qupath.lib.roi.ROIs
+import qupath.lib.roi.interfaces.ROI
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class ChangesTest {
-  val plane = getDefaultPlane()
-  val roi1 = ROIs.createRectangleROI(0.0, 0.0, 100.0, 100.0, plane)
-  val roi2 = ROIs.createRectangleROI(1.0, 2.0, 100.0, 100.0, plane)
+  val plane: ImagePlane = getDefaultPlane()
+  val roi1: ROI = ROIs.createRectangleROI(0.0, 0.0, 100.0, 100.0, plane)
+  val roi2: ROI = ROIs.createRectangleROI(1.0, 2.0, 100.0, 100.0, plane)
   private val gson = GsonTools.getInstance()
 
   fun geometryToPoints(geomJson: JsonObject): List<Point2> {
@@ -39,7 +41,7 @@ class ChangesTest {
     val newJsonStr = gson.toJson(po2)
     val oldObject = gson.fromJson(oldJsonStr, JsonObject::class.java)
     val newObject = gson.fromJson(newJsonStr, JsonObject::class.java)
-    val diffs = Generator.diffPathObjects(oldObject, newObject)
+    val diffs = Generator.diffJsonObjects(oldObject, newObject)
 
     assertEquals(setOf("geometry", "properties"), diffs.keys)
     diffs["geometry"]?.asJsonObject?.let { geomJson ->
@@ -69,8 +71,8 @@ class ChangesTest {
     createdObj.name = "added_po"
 
     val oldTrackedObjects = mapOf(
-      changedObjOld.id to changedObjOld,
-      deletedObj.id to deletedObj
+      changedObjOld.id to changedObjOld.toJsonObject(),
+      deletedObj.id to deletedObj.toJsonObject()
     )
     val newTrackedObjects = mapOf(
       changedObjNew.id to changedObjNew,


### PR DESCRIPTION
Really excited about this one – after all it fixes #42 , the answer to the question of life, the universe, and everything.

Primarily, this PR registers a QuPath listener so that we stay informed of changes to the object hierarchy, then, store change events accordingly.

More granular change events save us from reading/writing the entire qpdata file in bulk (which can take 10s or more for larger files).

Some interesting things;

1. Deleting multiple objects is registered as an overall hierarchy change, not a deletion.
2. We don't need to track path detection objects, so we skip those (or do we?).
3. Because hierarchy objects are modified in place, we have to store our own representation to track changes.

Example tracked changes in comments.

Now that we have these events available it's time to apply them in #43 so that we can move on to saving/fetching these smaller objects.