### PR TITLE
Remote image data store

### DIFF
--- a/src/main/java/dimilab/qupath/ext/omezarr/ui/InterfaceController.java
+++ b/src/main/java/dimilab/qupath/ext/omezarr/ui/InterfaceController.java
@@ -1,10 +1,10 @@
 package dimilab.qupath.ext.omezarr.ui;
 
+import dimilab.qupath.ext.omezarr.CloudOmeZarrExtension;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Spinner;
 import javafx.scene.layout.VBox;
-import dimilab.qupath.ext.omezarr.CloudOmeZarrExtension;
 import qupath.fx.dialogs.Dialogs;
 
 import java.io.IOException;
@@ -21,6 +21,7 @@ public class InterfaceController extends VBox {
 
     /**
      * Create a new instance of the interface controller.
+     *
      * @return a new instance of the interface controller
      * @throws IOException If reading the extension FXML files fails.
      */
@@ -34,6 +35,7 @@ public class InterfaceController extends VBox {
      * Fields in this class tagged with <code>@FXML</code> correspond to UI elements, and methods tagged with <code>@FXML</code> are methods triggered by actions on the UI (e.g., mouse clicks).
      * <p>
      * We consider the use of FXML to be "best practice" for UI creation, as it separates logic from layout and enables easier use of CSS. However, it is not mandatory, and you could instead define the layout of the UI using code.
+     *
      * @throws IOException If the FXML can't be read successfully.
      */
     private InterfaceController() throws IOException {

--- a/src/main/kotlin/dimilab/omezarr/CloudZarrStore.kt
+++ b/src/main/kotlin/dimilab/omezarr/CloudZarrStore.kt
@@ -12,7 +12,7 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.file.Path
-import java.util.TreeSet
+import java.util.*
 import java.util.stream.Stream
 
 class CloudZarrStore(val backingStore: Store) : Store {

--- a/src/main/kotlin/dimilab/omezarr/CloudZarrStore.kt
+++ b/src/main/kotlin/dimilab/omezarr/CloudZarrStore.kt
@@ -1,22 +1,23 @@
-package dimilab.qupath.ext.omezarr
+package dimilab.omezarr
 
-import com.bc.zarr.ZarrConstants.*
+import com.bc.zarr.ZarrConstants
 import com.bc.zarr.storage.FileSystemStore
 import com.bc.zarr.storage.Store
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.file.Path
-import java.util.*
+import java.util.TreeSet
 import java.util.stream.Stream
 
 class CloudZarrStore(val backingStore: Store) : Store {
   companion object {
-    private val logger = org.slf4j.LoggerFactory.getLogger(CloudZarrStore::class.java)
+    private val logger = LoggerFactory.getLogger(CloudZarrStore::class.java)
 
     private val cachedZarrs = mutableMapOf<Path, CloudZarrStore>()
 
@@ -95,9 +96,9 @@ class CloudZarrStore(val backingStore: Store) : Store {
   }
 
   private val cachedExtensions = listOf(
-    FILENAME_DOT_ZATTRS,
-    FILENAME_DOT_ZARRAY,
-    FILENAME_DOT_ZGROUP,
+    ZarrConstants.FILENAME_DOT_ZATTRS,
+    ZarrConstants.FILENAME_DOT_ZARRAY,
+    ZarrConstants.FILENAME_DOT_ZGROUP,
   )
 
   private fun isAttribute(key: String?): Boolean {

--- a/src/main/kotlin/dimilab/omezarr/OmeXmlUtils.kt
+++ b/src/main/kotlin/dimilab/omezarr/OmeXmlUtils.kt
@@ -1,6 +1,6 @@
-package dimilab.qupath.ext.omezarr
+package dimilab.omezarr
 
-import dimilab.qupath.ext.omezarr.OmeXmlUtils.Companion.logger
+import dimilab.omezarr.OmeXmlUtils.Companion.logger
 import loci.common.services.ServiceFactory
 import loci.common.xml.XMLTools
 import loci.formats.ome.OMEXMLMetadata
@@ -8,6 +8,7 @@ import loci.formats.services.OMEXMLService
 import ome.xml.model.enums.PixelType
 import ome.xml.model.primitives.Color
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.xml.sax.SAXException
 import qupath.lib.common.ColorTools
 import qupath.lib.images.servers.ImageChannel
@@ -22,7 +23,7 @@ import kotlin.random.Random
 
 class OmeXmlUtils {
   companion object {
-    val logger: Logger = org.slf4j.LoggerFactory.getLogger(OmeZarrUtils::class.java)
+    val logger: Logger = LoggerFactory.getLogger(OmeXmlUtils::class.java)
   }
 }
 

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
@@ -1,14 +1,7 @@
 package dimilab.qupath.ext.omezarr
 
 import com.bc.zarr.ZarrGroup
-import dimilab.omezarr.CloudZarrStore
-import dimilab.omezarr.ScaleLevel
-import dimilab.omezarr.checkPixelType
-import dimilab.omezarr.getZarrRoot
-import dimilab.omezarr.omeChannelsToQuPath
-import dimilab.omezarr.omeXmlPixelTypeToQupath
-import dimilab.omezarr.parseOmeXmlMetadata
-import dimilab.omezarr.renderZarrToBufferedImage
+import dimilab.omezarr.*
 import dimilab.qupath.quietLoggers
 import loci.formats.ome.OMEXMLMetadata
 import org.apache.commons.cli.*

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
@@ -1,7 +1,14 @@
 package dimilab.qupath.ext.omezarr
 
-import com.bc.zarr.ZarrArray
 import com.bc.zarr.ZarrGroup
+import dimilab.omezarr.CloudZarrStore
+import dimilab.omezarr.ScaleLevel
+import dimilab.omezarr.checkPixelType
+import dimilab.omezarr.getZarrRoot
+import dimilab.omezarr.omeChannelsToQuPath
+import dimilab.omezarr.omeXmlPixelTypeToQupath
+import dimilab.omezarr.parseOmeXmlMetadata
+import dimilab.omezarr.renderZarrToBufferedImage
 import dimilab.qupath.quietLoggers
 import loci.formats.ome.OMEXMLMetadata
 import org.apache.commons.cli.*
@@ -43,16 +50,6 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
   private val metadata: ImageServerMetadata
   private val originalArgs = arrayOf(*args)
   private val serverArgs: OmeZarrArgs
-
-  data class ScaleLevel(
-    val path: String,
-    val width: Int,
-    val height: Int,
-    val tileWidth: Int,
-    val tileHeight: Int,
-    val zarrArray: ZarrArray,
-    // TODO: coordinateTransforms
-  )
 
   // The image has several levels of detail.
   private val scaleLevels: List<ScaleLevel>

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
@@ -39,7 +39,8 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
   private val zarrRoot: Path
 
   data class OmeZarrArgs(
-    val remoteQpDataPath: URI?,
+    val remoteQpDataPath: URI? = null,
+    val changesetRoot: URI? = null,
   )
 
   data class OmeZarrMetadata(
@@ -49,7 +50,7 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
 
   private val metadata: ImageServerMetadata
   private val originalArgs = arrayOf(*args)
-  private val serverArgs: OmeZarrArgs
+  val serverArgs: OmeZarrArgs
 
   // The image has several levels of detail.
   private val scaleLevels: List<ScaleLevel>
@@ -111,6 +112,12 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
       .desc("set the remote QuPath qpdata path")
       .build()
     options.addOption(remoteFileOption)
+    val changesetRootOption = Option.builder().longOpt("changeset-root")
+      .argName("changeset-root")
+      .hasArg()
+      .desc("set the remote changeset root path, gs://bucket/path")
+      .build()
+    options.addOption(changesetRootOption)
 
     val parser: CommandLineParser = DefaultParser()
     val line: CommandLine? = parser.parse(options, args)
@@ -121,8 +128,15 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
       null
     }
 
+    val changesetRootUri = if (line?.hasOption("changeset-root") == true) {
+      URI.create(line.getOptionValue("changeset-root"))
+    } else {
+      null
+    }
+
     return OmeZarrArgs(
       remoteQpDataPath = remoteQpDataUri,
+      changesetRoot = changesetRootUri,
     )
   }
 

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudStorageUtils.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudStorageUtils.kt
@@ -95,3 +95,9 @@ fun URI.toBlobId(): BlobId {
 fun String.toBlobId(): BlobId {
   return BlobId.fromGsUtilUri(this)
 }
+
+inline val BlobInfo.gsUri: String
+  get() = this.blobId.toGsUtilUri()
+
+inline val BlobId.gsUri: String
+  get() = this.toGsUtilUri()

--- a/src/main/kotlin/dimilab/qupath/pathobjects/Utils.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/Utils.kt
@@ -1,26 +1,30 @@
 package dimilab.qupath.pathobjects
 
+import com.google.gson.JsonObject
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonToken
 import com.google.gson.stream.JsonWriter
 import dimilab.qupath.pathobjects.Utils.Companion.logger
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import qupath.lib.common.ColorTools
+import qupath.lib.io.GsonTools
 import qupath.lib.objects.PathObject
 import java.time.Instant
 
 class Utils {
   companion object {
-    val logger = org.slf4j.LoggerFactory.getLogger(Utils::class.java)
+    val logger: Logger = LoggerFactory.getLogger(Utils::class.java)
   }
 }
 
 
-fun PathObject.toJsonObject(): com.google.gson.JsonObject {
+fun PathObject.toJsonObject(): JsonObject {
   // Is this truly the best way: going from object to string then parsed to JSON object?
-  val gson = qupath.lib.io.GsonTools.getInstance()
+  val gson = GsonTools.getInstance()
   val jsonStr = gson.toJson(this)
-  return gson.fromJson(jsonStr, com.google.gson.JsonObject::class.java)
+  return gson.fromJson(jsonStr, JsonObject::class.java)
 }
 
 class InstantTypeAdapter : TypeAdapter<Instant>() {

--- a/src/main/kotlin/dimilab/qupath/pathobjects/changes/Applier.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/changes/Applier.kt
@@ -156,6 +156,10 @@ object Applier {
             }
           }
 
+          "objectType" -> {
+            /* ignore; shows up in non-granular property diffs */
+          }
+
           else -> {
             logger.warn("Unknown property change: $key")
           }

--- a/src/main/kotlin/dimilab/qupath/pathobjects/changes/CloudStorageStore.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/changes/CloudStorageStore.kt
@@ -1,0 +1,253 @@
+package dimilab.qupath.pathobjects.changes
+
+import com.google.cloud.storage.BlobId
+import com.google.cloud.storage.BlobInfo
+import com.google.cloud.storage.Storage
+import com.google.cloud.storage.StorageOptions
+import dimilab.qupath.ext.omezarr.gsUri
+import dimilab.qupath.ext.omezarr.toBlobId
+import dimilab.qupath.pathobjects.changes.Event.Companion.gson
+import kotlinx.coroutines.*
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.math.max
+
+interface StoreListener {
+  fun onNewEvents(events: List<Event>)
+}
+
+class CloudStorageStore {
+  companion object {
+    private val logger = LoggerFactory.getLogger(CloudStorageStore::class.java)
+  }
+
+  private val gcsService: Storage
+  private val ioDispatcher: CoroutineDispatcher
+  private val bucket: String
+  private val prefix: String
+
+  private val listeners = CopyOnWriteArrayList<StoreListener>()
+
+  private val currentSyncLock = ReentrantLock()
+  private var currentSync: Deferred<Unit>? = null
+  private val writeQueue = mutableListOf<Event>()
+
+  private val lastSeenChangesetLock = ReentrantLock()
+  private var lastSeenChangesetId = 0
+
+  constructor(
+    rootUri: URI,
+    storage: Storage = StorageOptions.getDefaultInstance().service,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+  ) : this(
+    rootUri.toBlobId(), storage, ioDispatcher
+  )
+
+  constructor(
+    rootBlobId: BlobId,
+    storage: Storage = StorageOptions.getDefaultInstance().service,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+  ) {
+    this.gcsService = storage
+    this.bucket = rootBlobId.bucket
+    this.prefix = ensureDirPrefix(rootBlobId.name)
+    this.ioDispatcher = ioDispatcher
+  }
+
+  fun syncEvents(blocking: Boolean) {
+    val deferred = currentSyncLock.withLock {
+      if (currentSync != null) {
+        logger.info("Sync already in progress, waiting for completion")
+        currentSync!!
+      } else {
+        logger.info("Launching new sync")
+        CoroutineScope(ioDispatcher).async {
+          try {
+            syncThreadMain()
+          } finally {
+            currentSyncLock.withLock {
+              currentSync = null
+            }
+          }
+        }.also { d ->
+          currentSync = d
+        }
+      }
+    }
+
+    if (blocking) {
+      runBlocking {
+        deferred.await()
+      }
+    }
+  }
+
+  private fun syncThreadMain() {
+    val changesets = indexChangesetBlobs().filter { (idx, _) -> idx > lastSeenChangesetId }
+    if (changesets.isEmpty()) {
+      logger.info("Sync completed, no new changesets found")
+      return
+    }
+
+    logger.info(
+      "Reading {} changeset IDs: {}", changesets.size, changesets.keys.sorted().joinToString(", ")
+    )
+    val indexedEvents = readChangesets(changesets)
+
+    val events = lastSeenChangesetLock.withLock {
+      indexedEvents.flatMap { (idx, events) ->
+        if (idx <= lastSeenChangesetId) {
+          logger.warn("Changeset ID {} is not newer than last seen ID {}", idx, lastSeenChangesetId)
+        }
+        events
+      }.also { _ ->
+        lastSeenChangesetId = max(lastSeenChangesetId, changesets.keys.max())
+      }
+    }
+
+    logger.info("Sync completed, {} new events found", events.size)
+
+    if (events.isNotEmpty()) {
+      // Note: no need for synchronization here, due to CopyOnWriteArrayList
+      listeners.forEach { it.onNewEvents(events) }
+    }
+  }
+
+  fun addListener(listener: StoreListener) {
+    // Note: no need for synchronization here, due to CopyOnWriteArrayList
+    listeners.addIfAbsent(listener)
+  }
+
+  fun removeListener(listener: StoreListener) {
+    // Note: no need for synchronization here, due to CopyOnWriteArrayList
+    listeners.remove(listener)
+  }
+
+  fun storeEvents(events: List<Event>) {
+    if (events.isEmpty()) return
+
+    synchronized(writeQueue) {
+      writeQueue.addAll(events)
+      logger.info("Enqueued {} change events for storage", events.size)
+    }
+
+    logger.info("Launching event write thread")
+    CoroutineScope(ioDispatcher).launch {
+      eventsWriteThread()
+    }
+  }
+
+  private fun eventsWriteThread() {
+    // FIXME?: if we fail, we have to put these back onto the queue
+    val events = synchronized(writeQueue) {
+      writeQueue.toList().also {
+        writeQueue.clear()
+      }
+    }
+
+    if (events.isEmpty()) {
+      logger.debug("No events to write, exiting write thread")
+      return
+    }
+
+    logger.info("Writing {} events to cloud storage", events.size)
+
+    // Compose JSONL content
+    val content = buildString {
+      events.forEach { append(gson.toJson(it)).append('\n') }
+    }.toByteArray(StandardCharsets.UTF_8)
+
+    // Determine the next available changelist file name and write with precondition
+    // Optimistically assume it's the next one we know about, sync & retry if not.
+    while (true) {
+      val wroteIndex = attemptSynchronizedWrite(content)
+
+      if (wroteIndex != null) {
+        logger.info("Successfully wrote {} events", events.size)
+        return
+      }
+
+      logger.debug("Syncing & retrying")
+      syncEvents(true)
+    }
+  }
+
+  private fun attemptSynchronizedWrite(content: ByteArray): Int? {
+    // This locks the entire store for the duration of the write.
+
+    lastSeenChangesetLock.withLock {
+      val attemptIndex = lastSeenChangesetId + 1
+      val blobName = prefix + changesetFilename(attemptIndex)
+      val blobInfo = BlobInfo.newBuilder(bucket, blobName).build()
+
+      try {
+        logger.debug("Attempting to write changeset to: {}", blobInfo.gsUri)
+        gcsService.create(blobInfo, content, Storage.BlobTargetOption.doesNotExist())
+        lastSeenChangesetId = attemptIndex
+        logger.info("Wrote changeset to location: {}", blobInfo.gsUri)
+        return attemptIndex
+      } catch (ex: com.google.cloud.storage.StorageException) {
+        if (ex.code != 412) {
+          throw ex
+        }
+
+        logger.debug("Changeset already exists: {}", blobInfo.gsUri)
+        return null
+      }
+    }
+  }
+
+  private fun indexChangesetBlobs(): Map<Int, BlobId> {
+    val blobs = mutableMapOf<Int, BlobId>()
+    val regex = Regex("^" + Regex.escape(prefix) + "events_(\\d+)\\.jsonl$")
+
+    var page = gcsService.list(
+      bucket, Storage.BlobListOption.prefix(prefix), Storage.BlobListOption.currentDirectory()
+    )
+    while (true) {
+      for (blob in page.iterateAll()) {
+        val name = blob.name
+        if (!name.endsWith(".jsonl")) continue
+        val match = regex.matchEntire(name)
+        if (match != null) {
+          val idx = match.groupValues[1].toInt()
+          blobs[idx] = blob.blobId
+        }
+      }
+      if (!page.hasNextPage()) break
+      page = page.nextPage
+    }
+
+    return blobs
+  }
+
+  private fun readChangesets(changesets: Map<Int, BlobId>): Map<Int, Sequence<Event>> {
+    val loadedEvents = changesets.mapValues { (idx, changeset) ->
+      logger.debug("Loading changeset {} from {}", idx, changeset.gsUri)
+      val jsonl = gcsService.readAllBytes(changeset).toString(StandardCharsets.UTF_8)
+      jsonl.lineSequence().mapNotNull { line ->
+        gson.fromJson(line, Event::class.java)
+      }
+    }
+
+    return loadedEvents
+  }
+
+  private fun ensureDirPrefix(name: String): String {
+    return when {
+      name.isEmpty() -> ""
+      name.endsWith('/') -> name
+      else -> "$name/"
+    }
+  }
+
+  private fun changesetFilename(index: Int): String = String.format("events_%010d.jsonl", index)
+
+  fun changesetRoot(): BlobId {
+    return BlobId.of(bucket, prefix)
+  }
+}

--- a/src/main/kotlin/dimilab/qupath/pathobjects/changes/CloudStorageStore.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/changes/CloudStorageStore.kt
@@ -38,7 +38,7 @@ class CloudStorageStore {
 
   private val lastSeenChangesetLock = ReentrantLock()
   var lastSeenChangesetId = 0
-    private set (value) {
+    private set(value) {
       logger.debug("Updating last seen changeset ID from {} to {}", field, value)
       field = value
     }

--- a/src/main/kotlin/dimilab/qupath/pathobjects/changes/CloudStorageStore.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/changes/CloudStorageStore.kt
@@ -37,7 +37,11 @@ class CloudStorageStore {
   private val writeQueue = mutableListOf<Event>()
 
   private val lastSeenChangesetLock = ReentrantLock()
-  private var lastSeenChangesetId = 0
+  var lastSeenChangesetId = 0
+    private set (value) {
+      logger.debug("Updating last seen changeset ID from {} to {}", field, value)
+      field = value
+    }
 
   constructor(
     rootUri: URI,
@@ -64,7 +68,7 @@ class CloudStorageStore {
         logger.info("Sync already in progress, waiting for completion")
         currentSync!!
       } else {
-        logger.info("Launching new sync")
+        logger.info("Launching new sync for store: {}", changesetRoot().gsUri)
         CoroutineScope(ioDispatcher).async {
           try {
             syncThreadMain()

--- a/src/main/kotlin/dimilab/qupath/pathobjects/changes/Events.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/changes/Events.kt
@@ -1,6 +1,11 @@
 package dimilab.qupath.pathobjects.changes
 
 import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import dimilab.qupath.pathobjects.InstantTypeAdapter
+import dimilab.qupath.pathobjects.changes.Event.Companion.gson
+import dimilab.qupath.pathobjects.changes.Event.Companion.logger
+import qupath.lib.io.GsonTools
 import java.time.Instant
 import java.util.*
 
@@ -8,6 +13,14 @@ sealed class Event {
   abstract val id: UUID
   abstract val timestamp: Instant
   abstract val eventType: String
+
+  companion object {
+    val logger = org.slf4j.LoggerFactory.getLogger(Event::class.java)
+    val gson = GsonTools.getDefaultBuilder()
+      .registerTypeAdapter(Instant::class.java, InstantTypeAdapter())
+      .registerTypeAdapter(Event::class.java, EventTypeAdapter())
+      .create()
+  }
 }
 
 data class CreateEvent(
@@ -31,3 +44,36 @@ data class DeleteEvent(
   override val timestamp: Instant = Instant.now(),
   override val eventType: String = "delete",
 ) : Event()
+
+class EventTypeAdapter : com.google.gson.TypeAdapter<Event>() {
+  override fun write(out: com.google.gson.stream.JsonWriter, value: Event?) {
+    if (value == null) {
+      out.nullValue()
+      return
+    }
+    out.value(Event.gson.toJson(value))
+  }
+
+  override fun read(input: com.google.gson.stream.JsonReader): Event? {
+    return try {
+      val json: JsonObject = gson.fromJson(input, JsonObject::class.java)
+      val eventType = json.get("eventType")
+      if (eventType !is JsonPrimitive) {
+        logger.error("Missing or invalid eventType in JSON: ${gson.toJson(json)}")
+        return null
+      }
+      when (eventType.asString) {
+        "create" -> gson.fromJson(json, CreateEvent::class.java)
+        "edit" -> gson.fromJson(json, EditEvent::class.java)
+        "delete" -> gson.fromJson(json, DeleteEvent::class.java)
+        else -> {
+          logger.error("Unknown eventType: ${json.get("eventType")}")
+          null
+        }
+      }
+    } catch (e: Exception) {
+      logger.error("Failed to parse event line: $this", e)
+      null
+    }
+  }
+}

--- a/src/main/kotlin/dimilab/qupath/pathobjects/changes/Tracker.kt
+++ b/src/main/kotlin/dimilab/qupath/pathobjects/changes/Tracker.kt
@@ -36,6 +36,25 @@ class Tracker {
     logger.info("Now tracking ${trackedObjects.size} objects; hierarchy root is: ${newHierarchy.rootObject.id}")
   }
 
+  fun retrackObjects(objectIds: Collection<UUID>, hierarchy: PathObjectHierarchy) {
+    val hierarchyObjects = hierarchy.getAllObjects(false).associateBy { it.id }
+
+    objectIds.forEach { id ->
+      if (!hierarchyObjects.containsKey(id)) {
+        trackedObjects.remove(id)
+      } else {
+        val pathObject = hierarchyObjects[id]!!
+        // We don't track detection object changes, so don't track anything beyond existence
+        if (pathObject is PathDetectionObject) {
+          trackedObjects[id] = JsonObject() // just so we know it's there
+        } else {
+          trackedObjects[id] = pathObject.toJsonObject()
+        }
+      }
+    }
+
+  }
+
   private fun makeCreateEvent(id: UUID, newJson: JsonObject): CreateEvent {
     return CreateEvent(
       id = id,

--- a/src/test/kotlin/dimilab/omezarr/CloudZarrStoreTest.kt
+++ b/src/test/kotlin/dimilab/omezarr/CloudZarrStoreTest.kt
@@ -1,4 +1,4 @@
-package dimilab.qupath.ext.omezarr
+package dimilab.omezarr
 
 import com.bc.zarr.storage.Store
 import io.mockk.every

--- a/src/test/kotlin/dimilab/omezarr/CloudZarrStoreTest.kt
+++ b/src/test/kotlin/dimilab/omezarr/CloudZarrStoreTest.kt
@@ -7,11 +7,6 @@ import io.mockk.spyk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertSame
-import kotlin.test.assertContentEquals
-import kotlin.test.assertTrue
 import java.io.ByteArrayInputStream
 import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
@@ -19,6 +14,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.*
 
 class CloudZarrStoreTest {
 

--- a/src/test/kotlin/dimilab/omezarr/OmeXmlUtilsTest.kt
+++ b/src/test/kotlin/dimilab/omezarr/OmeXmlUtilsTest.kt
@@ -1,14 +1,14 @@
-package dimilab.qupath.ext.omezarr
+package dimilab.omezarr
 
 import kotlin.io.path.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class OmeXmlUtilsTest {
-  private val testZarrRootUri = CloudOmeZarrServer::class.java.classLoader.getResource("test.zarr/")?.toURI()
+  private val testZarrRootUri = OmeXmlUtilsTest::class.java.classLoader.getResource("test.zarr/")?.toURI()
     ?: throw IllegalStateException("Could not find test.zarr")
 
-  private val testOmeMetadataRootUri = CloudOmeZarrServer::class.java.classLoader.getResource("test-ome-metadata/")?.toURI()
+  private val testOmeMetadataRootUri = OmeXmlUtilsTest::class.java.classLoader.getResource("test-ome-metadata/")?.toURI()
     ?: throw IllegalStateException("Could not find test-ome-metadata")
 
   @Test

--- a/src/test/kotlin/dimilab/omezarr/OmeXmlUtilsTest.kt
+++ b/src/test/kotlin/dimilab/omezarr/OmeXmlUtilsTest.kt
@@ -8,8 +8,9 @@ class OmeXmlUtilsTest {
   private val testZarrRootUri = OmeXmlUtilsTest::class.java.classLoader.getResource("test.zarr/")?.toURI()
     ?: throw IllegalStateException("Could not find test.zarr")
 
-  private val testOmeMetadataRootUri = OmeXmlUtilsTest::class.java.classLoader.getResource("test-ome-metadata/")?.toURI()
-    ?: throw IllegalStateException("Could not find test-ome-metadata")
+  private val testOmeMetadataRootUri =
+    OmeXmlUtilsTest::class.java.classLoader.getResource("test-ome-metadata/")?.toURI()
+      ?: throw IllegalStateException("Could not find test-ome-metadata")
 
   @Test
   fun testOmeChannelsToQuPath() {

--- a/src/test/kotlin/dimilab/omezarr/OmeZarrUtilsTest.kt
+++ b/src/test/kotlin/dimilab/omezarr/OmeZarrUtilsTest.kt
@@ -1,4 +1,4 @@
-package dimilab.qupath.ext.omezarr
+package dimilab.omezarr
 
 import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem
 import java.net.URI
@@ -39,7 +39,7 @@ class OmeZarrUtilsTest {
   @Test
   fun getZarrRoot_unsupported() {
     val uri = URI.create("s3://a-bucket/folder/animage.zarr/")
-    val exception = kotlin.runCatching { getZarrRoot(uri) }.exceptionOrNull()
+    val exception = runCatching { getZarrRoot(uri) }.exceptionOrNull()
     assertIs<IllegalArgumentException>(exception)
     assertEquals("Unsupported scheme 's3'", exception?.message)
   }

--- a/src/test/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServerBuilderTest.kt
+++ b/src/test/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServerBuilderTest.kt
@@ -1,17 +1,7 @@
 package dimilab.qupath.ext.omezarr
 
-import com.google.cloud.storage.BlobId
-import com.google.cloud.storage.BlobInfo
-import com.google.cloud.storage.StorageOptions
-import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
-import io.mockk.every
-import io.mockk.mockkStatic
 import java.io.File
 import java.net.URI
-import java.nio.file.Files
-import kotlin.io.path.isDirectory
-import kotlin.io.path.relativeTo
-import kotlin.io.path.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/src/test/kotlin/dimilab/qupath/pathobjects/changes/CloudStorageStoreTest.kt
+++ b/src/test/kotlin/dimilab/qupath/pathobjects/changes/CloudStorageStoreTest.kt
@@ -1,0 +1,275 @@
+package dimilab.qupath.pathobjects.changes
+
+import com.google.api.gax.paging.Page
+import com.google.cloud.storage.*
+import com.google.gson.JsonObject
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.*
+import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+class CloudStorageStoreTest {
+
+  // Manual dispatcher to deterministically execute enqueued coroutine tasks
+  private class ManualDispatcher : CoroutineDispatcher() {
+    private val queue: BlockingQueue<Runnable> = LinkedBlockingQueue()
+
+    override fun dispatch(context: kotlin.coroutines.CoroutineContext, block: Runnable) {
+      queue.add(block)
+    }
+
+    fun runNext(): Boolean {
+      val task = queue.poll() ?: return false
+      task.run()
+      return true
+    }
+  }
+
+  private fun makeStorageWithBacking(
+    bucket: String, backing: ConcurrentMap<String, ByteArray>,
+    onList: ((prefix: String?) -> Unit)? = null,
+    onCreate: ((name: String) -> Unit)? = null,
+  ): Storage {
+    val storage = mockk<Storage>()
+
+    // list: ignore options content; just return all objects in backing; call onList hook
+    every { storage.list(any<String>(), any<Storage.BlobListOption>(), any<Storage.BlobListOption>()) } answers {
+      onList?.invoke(null)
+      val blobs = backing.keys.toList().map { name: String ->
+        val blob = mockk<Blob>()
+        every { blob.name } returns name
+        every { blob.blobId } returns BlobId.of(bucket, name)
+        blob
+      }
+      object : Page<Blob> {
+        override fun getValues(): MutableIterable<Blob> = blobs.toMutableList()
+        override fun iterateAll(): MutableIterable<Blob> = blobs.toMutableList()
+        override fun getNextPage(): Page<Blob>? = null
+        override fun hasNextPage(): Boolean = false
+        override fun getNextPageToken(): String? = null
+      }
+    }
+
+    // readAllBytes
+    every { storage.readAllBytes(any<BlobId>()) } answers {
+      val id = firstArg<BlobId>()
+      backing[id.name] ?: ByteArray(0)
+    }
+
+    // create with doesNotExist precondition
+    every { storage.create(any<BlobInfo>(), any<ByteArray>(), eq(Storage.BlobTargetOption.doesNotExist())) } answers {
+      val info = firstArg<BlobInfo>()
+      val content = secondArg<ByteArray>()
+      val name = info.name
+      synchronized(backing) {
+        if (backing.containsKey(name)) {
+          throw StorageException(412, "Precondition Failed")
+        }
+        backing[name] = content
+      }
+      onCreate?.invoke(name)
+      mockk<Blob>(relaxed = true)
+    }
+
+    return storage
+  }
+
+  @Test
+  fun sync_concurrentJoinAndSeparateRuns() {
+    val bucket = "test-bucket"
+    val prefix = "changes/"
+    val uri = URI.create("gs://$bucket/$prefix")
+
+    val objects = ConcurrentHashMap<String, ByteArray>()
+
+    val listCalls = AtomicInteger(0)
+    val listEnter = CountDownLatch(1)
+    val releaseList = CountDownLatch(1)
+
+    val storage = mockk<Storage>()
+    every { storage.list(any<String>(), any<Storage.BlobListOption>(), any<Storage.BlobListOption>()) } answers {
+      listCalls.incrementAndGet()
+      listEnter.countDown()
+      // block first call until released; subsequent calls proceed immediately
+      if (releaseList.count == 1L) {
+        releaseList.await(2, TimeUnit.SECONDS)
+      }
+      val blobs = objects.keys.toList().map { name: String ->
+        val blob = mockk<Blob>()
+        every { blob.name } returns name
+        every { blob.blobId } returns BlobId.of(bucket, name)
+        blob
+      }
+      object : Page<Blob> {
+        override fun getValues(): MutableIterable<Blob> = blobs.toMutableList()
+        override fun iterateAll(): MutableIterable<Blob> = blobs.toMutableList()
+        override fun getNextPage(): Page<Blob>? = null
+        override fun hasNextPage(): Boolean = false
+        override fun getNextPageToken(): String? = null
+      }
+    }
+    every { storage.readAllBytes(any<BlobId>()) } answers { ByteArray(0) }
+    every {
+      storage.create(
+        any<BlobInfo>(),
+        any<ByteArray>(),
+        eq(Storage.BlobTargetOption.doesNotExist())
+      )
+    } answers { mockk<Blob>(relaxed = true) }
+
+    val dispatcher = Executors.newFixedThreadPool(2).asCoroutineDispatcher()
+    val store = CloudStorageStore(uri, storage, dispatcher)
+
+    // Launch first sync non-blocking so it runs in background and blocks inside list
+    store.syncEvents(false)
+
+    // Ensure first list started and is blocking
+    assertTrue(listEnter.await(1, TimeUnit.SECONDS))
+
+    // Now call sync again while first is in progress; it should join and not trigger another list immediately
+    val joinFinished = CountDownLatch(1)
+    thread {
+      store.syncEvents(true)
+      joinFinished.countDown()
+    }
+
+    // Give a little time; list should have been called only once so far
+    Thread.sleep(100)
+    assertEquals(1, listCalls.get(), "Second sync should have joined the first one")
+
+    // Release the first list to complete sync
+    releaseList.countDown()
+
+    // Wait for the joiner to complete
+    assertTrue(joinFinished.await(1, TimeUnit.SECONDS))
+
+    // Now, trigger two separate syncs at different times; each should call list
+    store.syncEvents(true)
+    store.syncEvents(true)
+    // Total list calls: 1 (first joined) + 2 (separate) = 3
+    assertEquals(3, listCalls.get())
+  }
+
+  @Test
+  fun write_concurrentCombinedVsSeparate() {
+    val bucket = "test-bucket"
+    val prefix = "changes/"
+    val uri = URI.create("gs://$bucket/$prefix")
+
+    val objects = ConcurrentHashMap<String, ByteArray>()
+
+    // Combined case using ManualDispatcher
+    run {
+      val manual = ManualDispatcher()
+      val created = CopyOnWriteArrayList<String>()
+      val storage = makeStorageWithBacking(bucket, objects, onCreate = { created.add(it) })
+      val store = CloudStorageStore(uri, storage, manual)
+
+      val e1 = CreateEvent(UUID.randomUUID(), fields = JsonObject())
+      val e2 = CreateEvent(UUID.randomUUID(), fields = JsonObject())
+
+      store.storeEvents(listOf(e1))
+      store.storeEvents(listOf(e2))
+
+      // Run first write thread: it should drain both events and write a single blob
+      manual.runNext()
+      // Run second write thread: it should find queue empty and do nothing
+      manual.runNext()
+
+      val createdOnce = created.filter { it.startsWith(prefix) }
+      assertEquals(1, createdOnce.size, "Combined write should create exactly one changeset")
+      assertTrue(createdOnce[0].endsWith("events_0000000001.jsonl"))
+      val content = objects[createdOnce[0]]!!.toString(StandardCharsets.UTF_8)
+      assertEquals(2, content.trim().lines().size)
+
+      // cleanup for next sub-test
+      objects.clear()
+      created.clear()
+    }
+
+    // Separate case using ManualDispatcher
+    run {
+      val manual = ManualDispatcher()
+      val created = CopyOnWriteArrayList<String>()
+      val storage = makeStorageWithBacking(bucket, objects, onCreate = { created.add(it) })
+      val store = CloudStorageStore(uri, storage, manual)
+
+      val e1 = CreateEvent(UUID.randomUUID(), fields = JsonObject())
+      val e2 = CreateEvent(UUID.randomUUID(), fields = JsonObject())
+
+      store.storeEvents(listOf(e1))
+      // Run first write before enqueuing the second
+      manual.runNext()
+
+      store.storeEvents(listOf(e2))
+      manual.runNext()
+
+      val createdOnce = created.filter { it.startsWith(prefix) }.sorted()
+      assertEquals(2, createdOnce.size, "Separate writes should create two changesets")
+      assertTrue(createdOnce[0].endsWith("events_0000000001.jsonl"))
+      assertTrue(createdOnce[1].endsWith("events_0000000002.jsonl"))
+    }
+  }
+
+  @Test
+  fun write_SyncAndRetrySuccess() {
+    val bucket = "test-bucket"
+    val prefix = "changes/"
+    val uri = URI.create("gs://$bucket/$prefix")
+
+    val objects = ConcurrentHashMap<String, ByteArray>()
+    // Preload index 1 to force 412 on first write attempt
+    objects["${prefix}events_0000000001.jsonl"] = "".toByteArray(StandardCharsets.UTF_8)
+
+    val created = CopyOnWriteArrayList<String>()
+
+    val storage = makeStorageWithBacking(bucket, objects, onCreate = { created.add(it) })
+
+    val dispatcher = Executors.newFixedThreadPool(2).asCoroutineDispatcher()
+    val store = CloudStorageStore(uri, storage, dispatcher)
+
+    val e1 = CreateEvent(UUID.randomUUID(), fields = JsonObject())
+
+    val done = CountDownLatch(1)
+
+    // Wrap storage.create to signal completion on success
+    // We need to re-stub create to add latch signal while delegating to backing
+    // Using MockK 'every' again on the same mock to override behavior
+    every { storage.create(any<BlobInfo>(), any<ByteArray>(), eq(Storage.BlobTargetOption.doesNotExist())) } answers {
+      val info = firstArg<BlobInfo>()
+      val content = secondArg<ByteArray>()
+      val name = info.name
+      synchronized(objects) {
+        if (objects.containsKey(name)) {
+          throw StorageException(412, "Precondition Failed")
+        }
+        objects[name] = content
+      }
+      created.add(name)
+      done.countDown()
+      mockk<Blob>(relaxed = true)
+    }
+
+    store.storeEvents(listOf(e1))
+
+    // Wait for success
+    assertTrue(done.await(2, TimeUnit.SECONDS), "Write did not complete in time")
+
+    // Make sure we wrote the right objects into the 2nd file
+    val createdNames = created.filter { it.startsWith(prefix) }
+    assertEquals(1, createdNames.size)
+    assertTrue(createdNames[0].endsWith("events_0000000002.jsonl"), "Write after sync should use next index")
+    val storedObjects = objects[createdNames[0]]!!.toString(StandardCharsets.UTF_8).trim().lines().map { Event.gson.fromJson(it, Event::class.java) }
+    assertEquals(listOf(e1), storedObjects)
+  }
+}

--- a/src/test/kotlin/dimilab/qupath/pathobjects/changes/CloudStorageStoreTest.kt
+++ b/src/test/kotlin/dimilab/qupath/pathobjects/changes/CloudStorageStoreTest.kt
@@ -7,7 +7,6 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -269,7 +268,8 @@ class CloudStorageStoreTest {
     val createdNames = created.filter { it.startsWith(prefix) }
     assertEquals(1, createdNames.size)
     assertTrue(createdNames[0].endsWith("events_0000000002.jsonl"), "Write after sync should use next index")
-    val storedObjects = objects[createdNames[0]]!!.toString(StandardCharsets.UTF_8).trim().lines().map { Event.gson.fromJson(it, Event::class.java) }
+    val storedObjects = objects[createdNames[0]]!!.toString(StandardCharsets.UTF_8).trim().lines()
+      .map { Event.gson.fromJson(it, Event::class.java) }
     assertEquals(listOf(e1), storedObjects)
   }
 }

--- a/src/test/kotlin/dimilab/qupath/pathobjects/changes/EventsTest.kt
+++ b/src/test/kotlin/dimilab/qupath/pathobjects/changes/EventsTest.kt
@@ -1,0 +1,101 @@
+package dimilab.qupath.pathobjects.changes
+
+import com.google.gson.JsonObject
+import java.time.Instant
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class EventsTest {
+  @Test
+  fun testDeserializeCreateEvent() {
+    val id = UUID.randomUUID()
+    val ts = Instant.now()
+    val json = """
+      {
+        "id": "${id}",
+        "timestamp": "${ts}",
+        "eventType": "create",
+        "fields": {
+          "name": "new object",
+          "geometry": { "type": "Point", "coordinates": [1.0, 2.0] }
+        }
+      }
+    """.trimIndent()
+
+    val event = Event.gson.fromJson(json, Event::class.java)
+    assertIs<CreateEvent>(event)
+    assertEquals(id, event.id)
+    assertEquals(ts, event.timestamp)
+    assertEquals("create", event.eventType)
+
+    val fields: JsonObject = event.fields
+    assertEquals("new object", fields.get("name").asString)
+    assertEquals("Point", fields.getAsJsonObject("geometry").get("type").asString)
+  }
+
+  @Test
+  fun testDeserializeEditEvent() {
+    val id = UUID.randomUUID()
+    val ts = Instant.now()
+    val json = """
+      {
+        "id": "${id}",
+        "timestamp": "${ts}",
+        "eventType": "edit",
+        "diff": {
+          "properties": { "name": "updated" },
+          "geometry": { "type": "Polygon" }
+        }
+      }
+    """.trimIndent()
+
+    val event = Event.gson.fromJson(json, Event::class.java)
+    assertIs<EditEvent>(event)
+    assertEquals(id, event.id)
+    assertEquals(ts, event.timestamp)
+    assertEquals("edit", event.eventType)
+
+    val diff: JsonObject = event.diff
+    assertEquals("updated", diff.getAsJsonObject("properties").get("name").asString)
+    assertEquals("Polygon", diff.getAsJsonObject("geometry").get("type").asString)
+  }
+
+  @Test
+  fun testDeserializeDeleteEvent() {
+    val id = UUID.randomUUID()
+    val ts = Instant.now()
+    val json = """
+      {
+        "id": "${id}",
+        "timestamp": "${ts}",
+        "eventType": "delete"
+      }
+    """.trimIndent()
+
+    val event = Event.gson.fromJson(json, Event::class.java)
+    assertIs<DeleteEvent>(event)
+    assertEquals(id, event.id)
+    assertEquals(ts, event.timestamp)
+    assertEquals("delete", event.eventType)
+  }
+
+  @Test
+  fun testDeserializeUnknownEventTypeReturnsNull() {
+    val id = UUID.randomUUID()
+    val ts = Instant.now()
+    val json = """
+      {
+        "id": "${id}",
+        "timestamp": "${ts}",
+        "eventType": "something-else",
+        "fields": { "foo": "bar" }
+      }
+    """.trimIndent()
+
+    val event: Event? = Event.gson.fromJson(json, Event::class.java)
+    assertNull(event)
+  }
+}

--- a/src/test/kotlin/dimilab/qupath/pathobjects/changes/TrackerTest.kt
+++ b/src/test/kotlin/dimilab/qupath/pathobjects/changes/TrackerTest.kt
@@ -1,13 +1,19 @@
 package dimilab.qupath.pathobjects.changes
 
+import com.google.gson.JsonObject
 import dimilab.qupath.pathobjects.Helpers.makeAnnotation
 import dimilab.qupath.pathobjects.Helpers.makeRectangleRoi
 import dimilab.qupath.pathobjects.geomToPoints
 import dimilab.qupath.pathobjects.pointsLoop
 import dimilab.qupath.pathobjects.toJsonObject
+import qupath.lib.objects.PathObjects
+import qupath.lib.objects.hierarchy.PathObjectHierarchy
+import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 
 class TrackerTest {
   @Test
@@ -20,12 +26,12 @@ class TrackerTest {
     val diffs = Tracker().diffJsonObjects(oldObject, newObject)
 
     assertEquals(setOf("geometry", "properties"), diffs.keys)
-    diffs["geometry"]?.asJsonObject?.let { geomJson ->
+    diffs["geometry"]!!.asJsonObject.let { geomJson ->
       assertEquals("Polygon", geomJson.get("type").asString)
       assertEquals(po2.roi.pointsLoop(), geomJson.geomToPoints())
     }
 
-    diffs["properties"]?.asJsonObject?.let { propsJson ->
+    diffs["properties"]!!.asJsonObject.let { propsJson ->
       val name = propsJson.get("name").asString
       assertEquals("po2", name)
     }
@@ -43,12 +49,12 @@ class TrackerTest {
     tracker.trackedObjects.putAll(
       listOf(
         changedObjOld.id to changedObjOld.toJsonObject(),
-        deletedObj.id to deletedObj.toJsonObject()
+        deletedObj.id to deletedObj.toJsonObject(),
       )
     )
     val newTrackedObjects = mapOf(
       changedObjNew.id to changedObjNew,
-      createdObj.id to createdObj
+      createdObj.id to createdObj,
     )
 
     val changes = tracker.trackBulkChanges(newTrackedObjects)
@@ -69,5 +75,45 @@ class TrackerTest {
     assertIs<CreateEvent>(createEvent)
     assert(createEvent.id == createdObj.id)
     assertEquals(createdObj.roi.pointsLoop(), createEvent.fields.getAsJsonObject("geometry").geomToPoints())
+  }
+
+  @Test
+  fun testRetrackObjects() {
+    // Create a hierarchy with some objects
+    val hierarchy = PathObjectHierarchy()
+    val ann1Hierarchy = makeAnnotation("fromHierarchy1")
+    val ann2Hierarchy = makeAnnotation("fromHierarchy2")
+    val det1 = PathObjects.createDetectionObject(makeRectangleRoi())
+    hierarchy.addObjects(listOf(ann1Hierarchy, ann2Hierarchy, det1))
+
+    // Create a tracker with different object states
+    val tracker = Tracker()
+    val ann1Tracker = makeAnnotation("fromTracker1").also { it.id = ann1Hierarchy.id }.toJsonObject()
+    val ann2Tracker = makeAnnotation("fromTracker2").also { it.id = ann2Hierarchy.id }.toJsonObject()
+    val deletedId = UUID.randomUUID()
+    val nonEmpty = JsonObject()
+    tracker.trackedObjects.putAll(
+      mapOf(
+        ann1Hierarchy.id to ann1Tracker,
+        ann2Hierarchy.id to ann2Tracker,
+        det1.id to nonEmpty,
+        deletedId to JsonObject(),
+      )
+    )
+
+    // Retrack ann1, det1, and deletedId (not ann2)
+    tracker.retrackObjects(listOf(ann1Hierarchy.id, det1.id, deletedId), hierarchy)
+
+    // ann1 should be updated from the tracker to the hierarchy version
+    assertEquals(ann1Hierarchy.toJsonObject(), tracker.trackedObjects[ann1Hierarchy.id])
+
+    // det1 should be present with empty json
+    assertEquals(JsonObject(), tracker.trackedObjects[det1.id])
+
+    // deletedId should be removed
+    assertFalse(tracker.trackedObjects.containsKey(deletedId))
+
+    // ann2 should remain unchanged (we did not retrack it)
+    assertEquals(ann2Tracker, tracker.trackedObjects[ann2Hierarchy.id])
   }
 }

--- a/src/test/kotlin/dimilab/qupath/pathobjects/changes/TrackerTest.kt
+++ b/src/test/kotlin/dimilab/qupath/pathobjects/changes/TrackerTest.kt
@@ -13,7 +13,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
-import kotlin.test.assertNotNull
 
 class TrackerTest {
   @Test


### PR DESCRIPTION
Very pleased with this one ✨ 

This PR implements a remote store for change events.
1. When sync'ing from remote, it notifies listeners of new events.
2. When saving to remote, it writes to the next available changeset file (using server-side preconditions to not overwrite other files).

The store ensures only one sync operation runs at a time (but a client may submit a non-blocking sync request). As for writes, if we fail due to a conflict with shared data, we re-sync to get the latest changeset ID then pick the next again.

For now, clients don't poll for data. They only receive new data when manually syncing (using the menu option) or, upon re-syncing when a write conflicts.

The local QuPath data, if saved, tracks the latest changeset index;

<img width="523" height="97" alt="Screenshot 2025-08-21 at 9 31 47 PM" src="https://github.com/user-attachments/assets/734cda88-9277-4350-8f1b-c5248b3285ea" />

such that subsequent image opens don't re-process already-seen events:

<img width="630" height="100" alt="Screenshot 2025-08-21 at 9 34 51 PM" src="https://github.com/user-attachments/assets/c02f805c-7c0d-44a0-96c2-aba55877ddc6" />


Fixes #46 