### PR TITLE
Reset changeset on server reset

### DIFF
--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrExtension.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrExtension.kt
@@ -1,5 +1,6 @@
 package dimilab.qupath.ext.omezarr
 
+import dimilab.qupath.ext.omezarr.AnnotationSyncer.Companion.LAST_CHANGESET_ID
 import javafx.beans.property.BooleanProperty
 import javafx.beans.property.Property
 import javafx.event.ActionEvent
@@ -175,6 +176,7 @@ class CloudOmeZarrExtension : QuPathExtension, GitHubProject {
     annotationSyncer.paused = true
     imageData.hierarchy.clearAll()
     imageData.hierarchy.addObjects(server.readPathObjects())
+    imageData.setProperty(LAST_CHANGESET_ID, 0)
     annotationSyncer.imageDataChanged(null, null, imageData)
     annotationSyncer.paused = false
     logger.info("Path objects refreshed")

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrExtension.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrExtension.kt
@@ -123,12 +123,12 @@ class CloudOmeZarrExtension : QuPathExtension, GitHubProject {
     syncTrackedChangesMenuItem.disableProperty().bind(enableExtensionProperty.not())
     menu.items.add(syncTrackedChangesMenuItem)
 
-    val refreshPathObjectsMenuItem = MenuItem("Reset from primary data")
+    val refreshPathObjectsMenuItem = MenuItem("Reset from server data")
     refreshPathObjectsMenuItem.onAction = EventHandler { _: ActionEvent? -> createResetFromRemoteStage() }
     refreshPathObjectsMenuItem.disableProperty().bind(enableExtensionProperty.not())
     menu.items.add(refreshPathObjectsMenuItem)
 
-    val saveToRemoteMenuItem = MenuItem("Overwrite remote primary data")
+    val saveToRemoteMenuItem = MenuItem("Overwrite server data")
     saveToRemoteMenuItem.onAction = EventHandler { _: ActionEvent? -> createOverwriteRemote() }
     saveToRemoteMenuItem.disableProperty().bind(enableExtensionProperty.not())
     menu.items.add(saveToRemoteMenuItem)
@@ -155,7 +155,7 @@ class CloudOmeZarrExtension : QuPathExtension, GitHubProject {
   private fun createResetFromRemoteStage() {
     val dialog = Alert(
       Alert.AlertType.CONFIRMATION,
-      "Delete all local path objects and refresh from server?"
+      "Replace all local objects with server data?"
     )
     dialog.showAndWait()
       .filter(Predicate { response: ButtonType? -> response == ButtonType.OK })
@@ -186,7 +186,7 @@ class CloudOmeZarrExtension : QuPathExtension, GitHubProject {
   private fun createOverwriteRemote() {
     val dialog = Alert(
       Alert.AlertType.CONFIRMATION,
-      "Overwrite shared primary copy with local data?"
+      "Overwrite shared server copy with current local data?"
     )
     dialog.showAndWait()
       .filter(Predicate { response: ButtonType? -> response == ButtonType.OK })


### PR DESCRIPTION
When resetting from remote data (wipe objects then reload path objects then resync tracked changes), make sure to also reset the local image data's last seen changeset id, so that it resets from zero as appropriate.

Fixes #52 