### PR TITLE
Clear cache using official method

### DIFF
--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncer.kt
@@ -76,8 +76,8 @@ class AnnotationSyncer : QuPathViewerListener, PathObjectHierarchyListener, Stor
     if (server is CloudOmeZarrServer && viewerDisplayListener == null) {
       logger.info("Connecting image display cache-busting listener")
       viewerDisplayListener = InvalidationListener {
-        logger.info("Clearing image region store cache")
-        viewer?.imageRegionStore?.cache?.clear()
+        logger.debug("Clearing image region store cache")
+        viewer?.imageRegionStore?.clearCache()
       }
       viewer?.imageDisplay?.changeTimestampProperty()?.addListener(viewerDisplayListener)
     } else {


### PR DESCRIPTION
When the image display settings (like visible channels) change, clear out the cache using `clearCache` which is smarter than just clearing the map. It cancels pending workers; importantly it also clears the thumbnail cache (explaining why it wasn't refreshing, TIL there are 2 caches).

I wasn't able to reproduce the outermost zoom not refreshing but this verifiably fixes the thumbnail.

Fixes #59, probably

Let's reopen #59 if we still see the outermost zoom not refreshing.