### PR TITLE
Return empty interrupted tiles

### DIFF
--- a/src/main/kotlin/dimilab/omezarr/CloudZarrStore.kt
+++ b/src/main/kotlin/dimilab/omezarr/CloudZarrStore.kt
@@ -60,11 +60,11 @@ class CloudZarrStore(val backingStore: Store) : Store {
       val deferredByteArray = synchronized(deferredFetches) {
         val existing = deferredFetches[key]
         if (existing != null) {
-          logger.debug("Waiting for existing fetch for key {}", key)
+          logger.trace("Waiting for existing fetch for key {}", key)
           return@synchronized existing
         }
 
-        logger.debug("Starting new fetch for key {}", key)
+        logger.trace("Starting new fetch for key {}", key)
         val deferred = makeDeferred(key)
         deferredFetches[key] = deferred
         deferred
@@ -91,6 +91,7 @@ class CloudZarrStore(val backingStore: Store) : Store {
         deferredFetches.remove(key)
       }
 
+      logger.debug("Read key {} from backing store ({} bytes)", key, byteArray.size)
       byteArray
     }
   }

--- a/src/main/kotlin/dimilab/omezarr/OmeZarrUtils.kt
+++ b/src/main/kotlin/dimilab/omezarr/OmeZarrUtils.kt
@@ -80,7 +80,15 @@ fun CoroutineScope.launchChannelReader(
 ) = async {
   val readOffset = intArrayOf(0, c, 0, y, x)
   logger.trace("Reading shape {} at offset {}", readShape, readOffset)
-  val readData = zarrArray.read(readShape, readOffset)
+
+  val readData = try {
+    zarrArray.read(readShape, readOffset)
+  } catch (e: InterruptedException) {
+    logger.info("Channel read interrupted, returning zeros for channel {}", c)
+    val zeroData = IntArray(width * height) { 0 }
+    raster.setSamples(0, 0, width, height, c, zeroData)
+    return@async
+  }
 
   when (readData) {
     is DoubleArray -> {

--- a/src/main/kotlin/dimilab/omezarr/OmeZarrUtils.kt
+++ b/src/main/kotlin/dimilab/omezarr/OmeZarrUtils.kt
@@ -68,16 +68,6 @@ private fun makeBuffer(width: Int, height: Int, numChannels: Int, pixelType: Pix
   }
 }
 
-fun CoroutineScope.launchZeroReader(
-  raster: WritableRaster,
-  c: Int,
-  width: Int,
-  height: Int,
-) = async {
-  val zeroData = IntArray(width * height) { 0 }
-  raster.setSamples(0, 0, width, height, c, zeroData)
-}
-
 fun CoroutineScope.launchChannelReader(
   zarrArray: ZarrArray,
   raster: WritableRaster,
@@ -145,7 +135,7 @@ fun renderZarrToBufferedImage(
       if (selectedChannels == null || c in selectedChannels) {
         launchChannelReader(zarrArray, raster, readShape, c, x, y, width, height)
       } else {
-        launchZeroReader(raster, c, width, height)
+        async { /* no-op */ }
       }
     }
 

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncer.kt
@@ -82,6 +82,7 @@ class AnnotationSyncer : QuPathViewerListener, PathObjectHierarchyListener, Stor
         if (newChannels != selectedChannels) {
           logger.debug("Clearing image region store cache")
           viewer?.imageRegionStore?.clearCache()
+          server.cache?.clear()
           selectedChannels = newChannels
         }
       }

--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
@@ -20,6 +20,7 @@ import qupath.lib.images.servers.TileRequest
 import qupath.lib.io.PathIO
 import qupath.lib.objects.PathObject
 import qupath.lib.objects.PathObjectReader
+import qupath.lib.regions.RegionRequest
 import java.awt.image.BufferedImage
 import java.awt.image.ColorModel
 import java.io.IOException
@@ -264,6 +265,10 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
       metadata.channels.size,
       selectedChannels,
     )
+  }
+
+  public override fun getCache(): MutableMap<RegionRequest?, BufferedImage?>? {
+    return super.getCache()
   }
 
   private fun getSelectedChannels(): Set<Int>? {


### PR DESCRIPTION
When tile reads are interrupted, the exception handling in the abstract image server doesn't clear out the pending tile read. This puts it into an inconsistent state where every subsequent tile read also fails, because the future task was resolved with an interrupted exception.

This PR intercepts interrupts when reading from the ZARR array and returns a zero'd out tile in case of interruption. At least, this should let us re-fetch the tile next time. To facilitate we also clear the image server's cache (there are many caching layers!).

Lastly– on the way, tweak the logging.

Fixes #62 (maybe?)