### PR TITLE
Handle read tile interrupt higher up

### DIFF
--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/CloudOmeZarrServer.kt
@@ -261,6 +261,7 @@ class CloudOmeZarrServer(private val zarrBaseUri: URI, vararg args: String) : Ab
       tileRequest.tileY,
       tileRequest.tileWidth,
       tileRequest.tileHeight,
+      tileRequest.level,
       metadata.pixelType,
       metadata.channels.size,
       selectedChannels,


### PR DESCRIPTION
Rather than handle interrupts just around the zarr read in the coroutine, handle higher up, where we block on the coroutines.

Error logs suggest the interrupt occurs in the `runBlocking` block anyhow …

This should fix #62  (again, hopefully)