### PR TITLE
Add remote store poll

### DIFF
--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncer.kt
@@ -47,6 +47,7 @@ class AnnotationSyncer : QuPathViewerListener, PathObjectHierarchyListener, Stor
     if (remoteStore != null) {
       logger.info("Disconnecting from remote store at: {}", remoteStore?.changesetRoot()?.gsUri)
       remoteStore?.removeListener(this)
+      remoteStore?.stopPolling()
       remoteStore = null
     }
 
@@ -68,7 +69,7 @@ class AnnotationSyncer : QuPathViewerListener, PathObjectHierarchyListener, Stor
       )
       remoteStore = CloudStorageStore(server.serverArgs.changesetRoot, lastSeenChangesetId = lastChangesetId).also {
         it.addListener(this)
-        it.syncEvents(blocking = false)
+        it.startPolling()
       }
     } else {
       logger.info("Not connecting image without changeset root: ${imageDataNew?.server?.javaClass?.name}")


### PR DESCRIPTION
Poll remote store for changes automatically. When events are found, retry more quickly. When not, increase the delay until a maximum. This should approximate "real time" collaboration when people are actively working together, while not excessively polling when not. (Should we delay more than 90s??)

Fixes #51 