### PR TITLE
Clear undo stack when applying remote changes

### DIFF
--- a/src/main/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncer.kt
+++ b/src/main/kotlin/dimilab/qupath/ext/omezarr/AnnotationSyncer.kt
@@ -2,6 +2,7 @@ package dimilab.qupath.ext.omezarr
 
 import dimilab.qupath.pathobjects.changes.*
 import javafx.beans.InvalidationListener
+import qupath.lib.gui.QuPathGUI
 import qupath.lib.gui.viewer.QuPathViewer
 import qupath.lib.gui.viewer.QuPathViewerListener
 import qupath.lib.images.ImageData
@@ -107,6 +108,10 @@ class AnnotationSyncer : QuPathViewerListener, PathObjectHierarchyListener, Stor
     val oldPaused = this.paused
     this.paused = true
     Applier.applyEventsToHierarchy(events, trackedHierarchy)
+    // Don't allow undo/redo through a changeset download.
+    // Ideally, we would disable undo manager using its private state
+    // just for the duration of this event application.
+    QuPathGUI.getInstance().undoRedoManager.clear()
     this.paused = oldPaused
     changeTracker.retrackObjects(events.map { it.id }.toSet(), trackedHierarchy)
   }


### PR DESCRIPTION
The change application events shouldn't be "undoable", they should be applied orthogonally to the user's workflow.

That is to say if I resize an annotation, then receive remote updates, then hit undo, it should only undo the resize (not whatever came from remote).

Instead, the remote changes seem to be batched into one large change; we don't identify them individually or in a group as something to be undone. But really these shouldn't be undoable… as above, they aren't properly "done" in the first place.

This PR clears the undo stack, which prevents the user from undoing, after receiving events. This means the user loses the ability to undo their events, but prevents the app from entering a bad state where received remote events are undone (written into the ledger, which the user can't modify as yet).

Fixes #70 