### PR TITLE
Revert "Don't rebuild JARs when publishing"

### DIFF
--- a/.github/workflows/jar.yml
+++ b/.github/workflows/jar.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Publish to GitHub Packages
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./gradlew publish -x compileJava -x compileKotlin -x processResources -x jar -x sourcesJar -x shadowJar
+        run: ./gradlew publish
 
   release:
     needs: build-jars


### PR DESCRIPTION
Reverts dimi-lab/qupath-extension-cloud-omezarr#75

This didn't work. 
https://github.com/dimi-lab/qupath-extension-cloud-omezarr/actions/runs/20546549569/job/59017875760

It tried running javadoc which depends on source. Let's avoid making this brittle by having to spell out steps to skip & do this another way.